### PR TITLE
Processing Pipeline for a pair of TDXHydro streamnet and basins files

### DIFF
--- a/examples/3_GenerateModifiedNestedSetIndex.ipynb
+++ b/examples/3_GenerateModifiedNestedSetIndex.ipynb
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -34,6 +34,7 @@
     "import re\n",
     "from importlib import reload\n",
     "\n",
+    "import pyarrow as pa\n",
     "import pyogrio\n",
     "import geopandas as gpd\n",
     "import pandas as pd\n",
@@ -198,7 +199,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -207,7 +208,7 @@
        "186.781267"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -215,6 +216,13 @@
    "source": [
     "# Get file size, in MB\n",
     "tdx_parquet_path.stat().st_size / 1_000_000"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Re-Read the Saved GeoParquet"
    ]
   },
   {
@@ -682,6 +690,267 @@
    ],
    "source": [
     "gdf.sort_index().info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Read Only Non-Geometry Columns for Speed\n",
+    "\n",
+    "This uses standard arguments in [`pandas.read_parquet()`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_parquet.html).\n",
+    "\n",
+    "NOTE: It is necessary to use the Pandas method, because [`geopandas.read_parquet()`](https://geopandas.org/en/stable/docs/reference/api/geopandas.read_parquet.html) will throw an error if no geometry field is read."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2.98 s ± 68 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "# Read entire file for comparison\n",
+    "gpd.read_parquet(tdx_parquet_path)\n",
+    "# 2.98 s ± 68 ms"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Select all non-geometry fields\n",
+    "columns_to_read = list(gdf.columns)\n",
+    "columns_to_read.remove('geometry')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "11.8 ms ± 481 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "# Read non-geometry fields\n",
+    "# requires using Pandas method rather than GeoPandas\n",
+    "pd.read_parquet(tdx_parquet_path, columns=columns_to_read)\n",
+    "# 11.8 ms ± 481 µs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Reading non-geometry fields gives a 250x speedup!!!**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Save df for use in selecting rows, below\n",
+    "df = pd.read_parquet(tdx_parquet_path, columns=columns_to_read)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Read Only Selected Rows for Speed\n",
+    "\n",
+    "This uses `**kwargs` in [`geopandas.read_parquet()`](https://geopandas.org/en/stable/docs/reference/api/geopandas.read_parquet.html) that are passed to [`pyarrow.parquet.read_table()`](https://arrow.apache.org/docs/python/generated/pyarrow.parquet.read_table.html#pyarrow.parquet.read_table).\n",
+    "\n",
+    "Although partioning the GeoParquet can dramatically improve read performance, it is also possible to gain some benefit for non-partitioned files. See https://dzone.com/articles/parquet-data-filtering-with-pandas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1.57 s ± 35.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "# Read 4897 rows where 'ROOT_ID'==750288662\n",
+    "gpd.read_parquet(\n",
+    "    tdx_parquet_path,\n",
+    "    filters=[('ROOT_ID', '==', 750288662)]\n",
+    ")\n",
+    "# 1.57 s ± 35.7 ms"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1.49 s ± 45.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "# Read 1 row where 'LINKNO'==750288662\n",
+    "gpd.read_parquet(\n",
+    "    tdx_parquet_path,\n",
+    "    filters=[('LINKNO', '==', 750288662)]\n",
+    ")\n",
+    "# 1.49 s ± 45.4 ms"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Reading selected rows gives up to a 2x speedup!!!**\n",
+    "- The limit appears to be constrained by the fact that pyarrow still needs to read the entire non-partioned"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1.44 s ± 7.06 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "pa.parquet.read_table(\n",
+    "    tdx_parquet_path,\n",
+    "    # filters=[('LINKNO', '==', 750288662)]\n",
+    ")\n",
+    "# 1.44 s ± 7.06 ms"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1.47 s ± 31.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "pa.parquet.read_table(\n",
+    "    tdx_parquet_path,\n",
+    "    filters=[('LINKNO', '==', 750288662)]\n",
+    ")\n",
+    "# 1.44 s ± 7.06 ms"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/aaufdenkampe/miniconda3/envs/hydrography/lib/python3.11/contextlib.py:137: RuntimeWarning: driver Parquet does not support open option FILTERS\n",
+      "  return next(self.gen)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1.57 s ± 15.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "pyogrio.read_arrow(tdx_parquet_path)\n",
+    "# 1.57 s ± 15.2 ms"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'layer_name': 'TDX_streamnet_7020038340_01_mnsi',\n",
+       " 'crs': 'EPSG:4326',\n",
+       " 'encoding': 'UTF-8',\n",
+       " 'fields': array(['DSLINKNO', 'USLINKNO1', 'USLINKNO2', 'ROOT_ID', 'DISCOVER_TIME',\n",
+       "        'FINISH_TIME', 'strmOrder', 'Length', 'Magnitude', 'DSContArea',\n",
+       "        'strmDrop', 'Slope', 'StraightL', 'USContArea', 'DOUTEND',\n",
+       "        'DOUTSTART', 'DOUTMID', 'LINKNO'], dtype=object),\n",
+       " 'dtypes': array(['int32', 'int32', 'int32', 'int32', 'int32', 'int32', 'int32',\n",
+       "        'float64', 'int32', 'float64', 'float64', 'float64', 'float64',\n",
+       "        'float64', 'float64', 'float64', 'float64', 'int32'], dtype=object),\n",
+       " 'fid_column': '',\n",
+       " 'geometry_name': 'geometry',\n",
+       " 'geometry_type': 'LineString',\n",
+       " 'features': 140097,\n",
+       " 'total_bounds': (-89.82122222222222,\n",
+       "  24.558999999998896,\n",
+       "  -66.14133333333214,\n",
+       "  46.44544444444445),\n",
+       " 'driver': 'Parquet',\n",
+       " 'capabilities': {'random_read': False,\n",
+       "  'fast_set_next_by_index': True,\n",
+       "  'fast_spatial_filter': False,\n",
+       "  'fast_feature_count': True,\n",
+       "  'fast_total_bounds': True},\n",
+       " 'layer_metadata': None,\n",
+       " 'dataset_metadata': None}"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pyogrio.read_info(tdx_parquet_path)"
    ]
   },
   {

--- a/examples/3_GenerateModifiedNestedSetIndex.ipynb
+++ b/examples/3_GenerateModifiedNestedSetIndex.ipynb
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -199,7 +199,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'TDX_streamnet_7020038340_01_mnsi.parquet'"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tdx_parquet_path.name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -208,7 +228,7 @@
        "186.781267"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -641,7 +661,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "24.5 ms ± 2.27 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "23.2 ms ± 966 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -705,14 +725,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2.98 s ± 68 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "3.04 s ± 193 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -725,7 +745,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -736,14 +756,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "11.8 ms ± 481 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+      "11.1 ms ± 217 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
@@ -764,7 +784,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -785,14 +805,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1.57 s ± 35.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "1.52 s ± 22.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -808,14 +828,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1.49 s ± 45.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "1.47 s ± 23.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -839,14 +859,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1.44 s ± 7.06 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "1.48 s ± 24.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -861,14 +881,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1.47 s ± 31.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "1.47 s ± 8.17 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -883,22 +903,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/aaufdenkampe/miniconda3/envs/hydrography/lib/python3.11/contextlib.py:137: RuntimeWarning: driver Parquet does not support open option FILTERS\n",
-      "  return next(self.gen)\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1.57 s ± 15.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "1.68 s ± 89.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -910,7 +922,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -944,7 +956,7 @@
        " 'dataset_metadata': None}"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -962,7 +974,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -1324,7 +1336,7 @@
        "[4897 rows x 18 columns]"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/examples/4_ProcessBasinToParquet.ipynb
+++ b/examples/4_ProcessBasinToParquet.ipynb
@@ -159,7 +159,7 @@
     "    GeoPackage basins files.\n",
     "\n",
     "    The new GeoParquet file renames 'streamID' to 'LINKNO', modifies it to be \n",
-    "    globally unique, and sets it as the index for interperability with streamnet data. \n",
+    "    globally unique, and sets it as the index for interoperability with streamnet data. \n",
     "    The GeoParquet file is saved with a filename in the form of:\n",
     "    `f\"TDX_streamreach_basins_{tdx_hydro_region}_01.parquet\"`.\n",
     "\n",
@@ -243,7 +243,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
@@ -267,7 +267,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [
     {
@@ -276,7 +276,7 @@
        "676.472978"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -288,7 +288,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [
     {
@@ -401,7 +401,7 @@
        "[140053 rows x 1 columns]"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 41,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -415,7 +415,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [
     {
@@ -436,7 +436,7 @@
        "LINKNO: [[750000001,750000002,750000003,750000004,750000005,...,750071698,750071699,750071700,750071701,750071702],[750071703,750071704,750071705,750071706,750071707,...,750215295,750215296,750215297,750215298,750215299],[750215300,750215301,750215302,750215303,750215304,...,750325343,750325935,750326527,750327119,750327711]]"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -457,17 +457,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "[PosixPath('/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/TDX_streamnet_7020038340_01.parquet'),\n",
+       " PosixPath('/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/TDX_streamnet_7020038340_01_mnsi_test.parquet'),\n",
        " PosixPath('/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/TDX_streamnet_7020038340_01_mnsi.parquet')]"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -483,16 +484,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'TDX_streamnet_7020038340_01_mnsi.parquet'"
+       "'TDX_streamnet_7020038340_01_mnsi_test.parquet'"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 44,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -504,7 +505,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [
     {
@@ -549,7 +550,7 @@
        "      dtype='int32', name='LINKNO', length=140097)"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 45,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -561,20 +562,26 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 28,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "# Try merging data\n",
-    "basins_gdf = gdf.copy(deep=True)\n",
-    "\n",
-    "columns_to_merge = ['DSContArea', 'USContArea']\n"
+    "## Merge Data\n",
+    "To confirm LINKNO matches, etc."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 46,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Try merging data\n",
+    "basins_gdf = gdf.copy(deep=True)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
    "metadata": {},
    "outputs": [
     {
@@ -595,38 +602,36 @@
     }
    ],
    "source": [
+    "columns_to_merge = ['DSContArea', 'USContArea']\n",
+    "\n",
     "# Merge confirms that their LINKNO values match\n",
     "# Although there are not as many basins as there are stream reaches!\n",
-    "pd.merge(\n",
+    "basins_test_gdf = pd.merge(\n",
     "    basins_gdf, \n",
     "    stream_mnsi_gdf[columns_to_merge], \n",
     "    how='right', \n",
     "    on='LINKNO',\n",
-    ").info()"
+    ")\n",
+    "basins_test_gdf.info()"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 30,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "33.2 ms ± 973 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
-     ]
-    }
-   ],
    "source": [
-    "%%timeit\n",
-    "# Merges are very fast!\n",
-    "pd.merge(basins_gdf, stream_mnsi_gdf[columns_to_merge], how='right', on='LINKNO')"
+    "**44 streams have no basins!!**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Streams with no Basins"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [
     {
@@ -634,43 +639,280 @@
      "output_type": "stream",
      "text": [
       "<class 'geopandas.geodataframe.GeoDataFrame'>\n",
-      "Index: 140053 entries, 750000001 to 750327711\n",
-      "Data columns (total 2 columns):\n",
-      " #   Column    Non-Null Count   Dtype   \n",
-      "---  ------    --------------   -----   \n",
-      " 0   ROOT_ID   140053 non-null  int32   \n",
-      " 1   geometry  140053 non-null  geometry\n",
-      "dtypes: geometry(1), int32(1)\n",
-      "memory usage: 2.7 MB\n"
+      "Index: 44 entries, 750000000 to 750020103\n",
+      "Data columns (total 18 columns):\n",
+      " #   Column         Non-Null Count  Dtype   \n",
+      "---  ------         --------------  -----   \n",
+      " 0   DSLINKNO       44 non-null     int32   \n",
+      " 1   USLINKNO1      44 non-null     int32   \n",
+      " 2   USLINKNO2      44 non-null     int32   \n",
+      " 3   ROOT_ID        44 non-null     int32   \n",
+      " 4   DISCOVER_TIME  44 non-null     int32   \n",
+      " 5   FINISH_TIME    44 non-null     int32   \n",
+      " 6   strmOrder      44 non-null     int32   \n",
+      " 7   Length         44 non-null     float64 \n",
+      " 8   Magnitude      44 non-null     int32   \n",
+      " 9   DSContArea     44 non-null     float64 \n",
+      " 10  strmDrop       44 non-null     float64 \n",
+      " 11  Slope          44 non-null     float64 \n",
+      " 12  StraightL      44 non-null     float64 \n",
+      " 13  USContArea     44 non-null     float64 \n",
+      " 14  DOUTEND        44 non-null     float64 \n",
+      " 15  DOUTSTART      44 non-null     float64 \n",
+      " 16  DOUTMID        44 non-null     float64 \n",
+      " 17  geometry       44 non-null     geometry\n",
+      "dtypes: float64(9), geometry(1), int32(8)\n",
+      "memory usage: 5.0 KB\n"
      ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>DSLINKNO</th>\n",
+       "      <th>USLINKNO1</th>\n",
+       "      <th>USLINKNO2</th>\n",
+       "      <th>ROOT_ID</th>\n",
+       "      <th>DISCOVER_TIME</th>\n",
+       "      <th>FINISH_TIME</th>\n",
+       "      <th>strmOrder</th>\n",
+       "      <th>Length</th>\n",
+       "      <th>Magnitude</th>\n",
+       "      <th>DSContArea</th>\n",
+       "      <th>strmDrop</th>\n",
+       "      <th>Slope</th>\n",
+       "      <th>StraightL</th>\n",
+       "      <th>USContArea</th>\n",
+       "      <th>DOUTEND</th>\n",
+       "      <th>DOUTSTART</th>\n",
+       "      <th>DOUTMID</th>\n",
+       "      <th>geometry</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>LINKNO</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>750000000</th>\n",
+       "      <td>750001777</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>750021317</td>\n",
+       "      <td>52</td>\n",
+       "      <td>53</td>\n",
+       "      <td>1</td>\n",
+       "      <td>3847.9</td>\n",
+       "      <td>1</td>\n",
+       "      <td>9.567845e+06</td>\n",
+       "      <td>42.07</td>\n",
+       "      <td>0.010933</td>\n",
+       "      <td>3233.7</td>\n",
+       "      <td>5.254868e+06</td>\n",
+       "      <td>45853.6</td>\n",
+       "      <td>49701.4</td>\n",
+       "      <td>47777.5</td>\n",
+       "      <td>LINESTRING (-69.67822 46.41356, -69.67822 46.4...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>750100709</th>\n",
+       "      <td>750101301</td>\n",
+       "      <td>750090644</td>\n",
+       "      <td>750068149</td>\n",
+       "      <td>750100710</td>\n",
+       "      <td>5</td>\n",
+       "      <td>16</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>6</td>\n",
+       "      <td>9.573266e+07</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>9.573266e+07</td>\n",
+       "      <td>7889.2</td>\n",
+       "      <td>7889.2</td>\n",
+       "      <td>7889.2</td>\n",
+       "      <td>LINESTRING (-69.74322 43.89322, -69.74322 43.8...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>750155209</th>\n",
+       "      <td>750155801</td>\n",
+       "      <td>750154617</td>\n",
+       "      <td>750113177</td>\n",
+       "      <td>750170058</td>\n",
+       "      <td>1767</td>\n",
+       "      <td>4980</td>\n",
+       "      <td>7</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1607</td>\n",
+       "      <td>2.410359e+10</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>2.410359e+10</td>\n",
+       "      <td>234019.3</td>\n",
+       "      <td>234019.3</td>\n",
+       "      <td>234019.3</td>\n",
+       "      <td>LINESTRING (-73.75744 42.54056, -73.75744 42.5...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>750127463</th>\n",
+       "      <td>750128055</td>\n",
+       "      <td>750141672</td>\n",
+       "      <td>750010841</td>\n",
+       "      <td>750129283</td>\n",
+       "      <td>3471</td>\n",
+       "      <td>4886</td>\n",
+       "      <td>6</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>708</td>\n",
+       "      <td>1.099047e+10</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.099047e+10</td>\n",
+       "      <td>423795.8</td>\n",
+       "      <td>423795.8</td>\n",
+       "      <td>423795.8</td>\n",
+       "      <td>LINESTRING (-78.23989 39.65089, -78.23989 39.6...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>750099079</th>\n",
+       "      <td>750099671</td>\n",
+       "      <td>750055269</td>\n",
+       "      <td>750055861</td>\n",
+       "      <td>750102638</td>\n",
+       "      <td>89</td>\n",
+       "      <td>96</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>4</td>\n",
+       "      <td>8.714499e+07</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>8.714499e+07</td>\n",
+       "      <td>68889.3</td>\n",
+       "      <td>68889.3</td>\n",
+       "      <td>68889.3</td>\n",
+       "      <td>LINESTRING (-76.08133 38.47233, -76.08133 38.4...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "            DSLINKNO  USLINKNO1  USLINKNO2    ROOT_ID  DISCOVER_TIME  \\\n",
+       "LINKNO                                                                 \n",
+       "750000000  750001777         -1         -1  750021317             52   \n",
+       "750100709  750101301  750090644  750068149  750100710              5   \n",
+       "750155209  750155801  750154617  750113177  750170058           1767   \n",
+       "750127463  750128055  750141672  750010841  750129283           3471   \n",
+       "750099079  750099671  750055269  750055861  750102638             89   \n",
+       "\n",
+       "           FINISH_TIME  strmOrder  Length  Magnitude    DSContArea  strmDrop  \\\n",
+       "LINKNO                                                                         \n",
+       "750000000           53          1  3847.9          1  9.567845e+06     42.07   \n",
+       "750100709           16          3     0.0          6  9.573266e+07      0.00   \n",
+       "750155209         4980          7     0.0       1607  2.410359e+10      0.00   \n",
+       "750127463         4886          6     0.0        708  1.099047e+10      0.00   \n",
+       "750099079           96          2     0.0          4  8.714499e+07      0.00   \n",
+       "\n",
+       "              Slope  StraightL    USContArea   DOUTEND  DOUTSTART   DOUTMID  \\\n",
+       "LINKNO                                                                        \n",
+       "750000000  0.010933     3233.7  5.254868e+06   45853.6    49701.4   47777.5   \n",
+       "750100709  0.000000        0.0  9.573266e+07    7889.2     7889.2    7889.2   \n",
+       "750155209  0.000000        0.0  2.410359e+10  234019.3   234019.3  234019.3   \n",
+       "750127463  0.000000        0.0  1.099047e+10  423795.8   423795.8  423795.8   \n",
+       "750099079  0.000000        0.0  8.714499e+07   68889.3    68889.3   68889.3   \n",
+       "\n",
+       "                                                    geometry  \n",
+       "LINKNO                                                        \n",
+       "750000000  LINESTRING (-69.67822 46.41356, -69.67822 46.4...  \n",
+       "750100709  LINESTRING (-69.74322 43.89322, -69.74322 43.8...  \n",
+       "750155209  LINESTRING (-73.75744 42.54056, -73.75744 42.5...  \n",
+       "750127463  LINESTRING (-78.23989 39.65089, -78.23989 39.6...  \n",
+       "750099079  LINESTRING (-76.08133 38.47233, -76.08133 38.4...  "
+      ]
+     },
+     "execution_count": 48,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "# Pandas insert allows placement of column at a specified location.\n",
-    "ROOT = \"ROOT_ID\"\n",
-    "basins_gdf.insert(0, ROOT, stream_mnsi_gdf[ROOT])\n",
-    "basins_gdf.info()"
+    "# Explore stream links with no basin geometry.\n",
+    "streams_no_basins_gdf = stream_mnsi_gdf[basins_test_gdf.geometry==None]\n",
+    "streams_no_basins_gdf.info()\n",
+    "streams_no_basins_gdf.head()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 5.64 ms, sys: 1.13 ms, total: 6.77 ms\n",
-      "Wall time: 5.03 ms\n"
-     ]
+     "data": {
+      "text/plain": [
+       "Length\n",
+       "0.0       43\n",
+       "3847.9     1\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 49,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "%%time\n",
-    "# Insert is even faster!\n",
-    "DISCOVER = \"DISCOVER_TIME\"\n",
-    "basins_gdf.insert(0, DISCOVER, stream_mnsi_gdf[DISCOVER])"
+    "streams_no_basins_gdf.Length.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**NOTE: All but one have zero stream length. The one with a lenghth is a headwater stream at the edge of the TDXHydroRegion.\n",
+    "\n",
+    "We will save these LINKNO for further exploration, below."
    ]
   },
   {
@@ -686,7 +928,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 63,
    "metadata": {},
    "outputs": [
     {
@@ -695,7 +937,7 @@
        "<module 'global_hydrography.process' from '/Users/aaufdenkampe/Documents/Python/global-hydrography/src/global_hydrography/process.py'>"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 63,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -705,31 +947,83 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `process_tdx_streams_basins()`\n",
+    "\n",
+    "Process a pair of TDXHydro streamnet and streamreach_basins files for \n",
+    "a given TDX Hydro Region, creating a set of GeoParquet files ready for use \n",
+    "by Model My Watershed. This processing includes:\n",
+    "- Reads the 'TDX_streamnet*.gpkg' file provided by NGA, converts LINKNO fields to \n",
+    "globally unique values, calculates and adds three new Modified Nested Set Index (MNSI) \n",
+    "fields, drops useless fields, and sets LINKNO as the index.\n",
+    "- Reads the 'TDX_streareach_basins*.gpkg' file provided by NGA, renames 'streamID' \n",
+    "to LINKNO, converts LINKNO to globally unique values, and sets LINKNO as the index.\n",
+    "- Moves MNSI fields from streament to basins datasets, saving a dataset of streams\n",
+    "that don't have a matching basin geometry.\n",
+    "- Saves three output datasets to GeoParquet files in the output directory.\n",
+    "\n",
+    "Parameters:  \n",
+    "- input_dir: Directory with raw TDX Hydro GeoPackage ('.gpkg') files. \n",
+    "- output_dir: Directory for saving processed GeoParquet ('.parquet') files. \n",
+    "- tdx_hydro_region: The 10-digit TDX Hydro Region \n",
+    "- preprocessor: An instance of the TDXPreprocessor class. \n",
+    "\n",
+    "Returns: a list of output file paths  \n",
+    "- TDX_streamnet_*.parquet  \n",
+    "- TDX_streamreach_basins_mnsi_*.parquet  \n",
+    "- TDX_streams_no_basin_*.parquet  \n"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 65,
    "metadata": {},
    "outputs": [],
    "source": [
     "# define a helper function for the operation\n",
     "def process_tdx_streams_basins(\n",
-    "    source_dir: Path,\n",
-    "    processed_dir: Path,\n",
+    "    input_dir: Path,\n",
+    "    output_dir: Path,\n",
     "    tdx_hydro_region: int, \n",
     "    preprocessor:TDXPreprocessor\n",
-    ") -> None:\n",
-    "    \n",
-    "    print (f\"Processing TDXHydroRegion = {tdx_hydro_region}\")\n",
+    ") -> list[Path]:\n",
+    "    \"\"\"Process a pair of TDXHydro streamnet and streamreach_basins files for \n",
+    "    a given TDX Hydro Region, creating a set of GeoParquet files ready for use \n",
+    "    by Model My Watershed. This processing includes:\n",
+    "    - Reads the 'TDX_streamnet*.gpkg' file provided by NGA, converts LINKNO fields to \n",
+    "    globally unique values, calculates and adds three new Modified Nested Set Index (MNSI) \n",
+    "    fields, drops useless fields, and sets LINKNO as the index.\n",
+    "    - Reads the 'TDX_streareach_basins*.gpkg' file provided by NGA, renames 'streamID' \n",
+    "    to LINKNO, converts LINKNO to globally unique values, and sets LINKNO as the index.\n",
+    "    - Moves MNSI fields from streament to basins datasets, saving a dataset of streams\n",
+    "    that don't have a matching basin geometry.\n",
+    "    - Saves three output datasets to GeoParquet files in the output directory.\n",
     "\n",
+    "    Parameters:\n",
+    "        input_dir: Directory with raw TDX Hydro GeoPackage ('.gpkg') files.\n",
+    "        output_dir: Directory for saving processed GeoParquet ('.parquet') files.\n",
+    "        tdx_hydro_region: The 10-digit TDX Hydro Region\n",
+    "        preprocessor: An instance of the TDXPreprocessor class.\n",
+    "\n",
+    "    Returns: a list of output file paths\n",
+    "        TDX_streamnet_*.parquet  \n",
+    "        TDX_streamreach_basins_mnsi_*.parquet  \n",
+    "        TDX_streams_no_basin_*.parquet  \n",
+    "    \"\"\"\n",
     "    # Get file paths\n",
+    "    print (f\"Processing TDXHydroRegion = {tdx_hydro_region}\")\n",
     "    streamnet_file, basins_file = gh.process.select_tdx_files(\n",
-    "        source_dir, tdx_hydro_region,'.gpkg')\n",
+    "        input_dir, tdx_hydro_region,'.gpkg')\n",
     "    \n",
     "\n",
     "    ## Process streamnet file ##\n",
     "    # get streamnet file metadata\n",
     "    streamnet_info = pyogrio.read_info(streamnet_file, layer=0)\n",
-    "    print(f\"  Reading: layer = {streamnet_info['layer_name']} last updated \n",
-    "          {streamnet_info['layer_metadata']['DBF_DATE_LAST_UPDATE']}\")\n",
+    "    print(f\"  Reading: layer = {streamnet_info['layer_name']} \" \n",
+    "        f\"last updated {streamnet_info['layer_metadata']['DBF_DATE_LAST_UPDATE']}\"\n",
+    "    )\n",
     "    \n",
     "    # open streamnet file as GeoDataFrame\n",
     "    streamnet_gdf = gpd.read_file(streamnet_file, engine='pyogrio', layer=0, use_arrow=True)\n",
@@ -741,8 +1035,8 @@
     "    preprocessor.tdx_drop_useless_columns(streamnet_gdf)\n",
     "\n",
     "    # compute the modified nested set index\n",
+    "    print('  Computing: modified nested set index')\n",
     "    streamnet_gdf = gh.mnsi.modified_nest_set_index(streamnet_gdf)\n",
-    "    print('  Computed: modified nested set index')\n",
     "\n",
     "    # Set 'LINKNO' as index, to facilitate selection\n",
     "    streamnet_gdf.set_index('LINKNO', inplace=True)\n",
@@ -767,21 +1061,93 @@
     "    basins_gdf.set_index('LINKNO', inplace=True)\n",
     "\n",
     "    \n",
-    "    ## Move MNSI fields from streamnet to basins\n",
-    "    DISCOVER = \"DISCOVER_TIME\"\n",
-    "    FINISH = \"FINISH_TIME\"\n",
-    "    ROOT = \"ROOT_ID\"\n",
-    "    # at column locations right after other LINK info\n",
-    "    for f in (FINISH, DISCOVER, ROOT):\n",
-    "        basins_gdf.insert(0, f, None)\n",
+    "    ## Move MNSI fields from streamnet to basins ##\n",
+    "    print(f\"  Moving MNSI files from streamnet to basins datasets.\")\n",
+    "    basins_mnsi_gdf, streams_no_basin_gdf = gh.process.create_basins_mnsi(\n",
+    "        basins_gdf,\n",
+    "        streamnet_gdf,\n",
+    "    )\n",
+    "    # Drop MNSI fields from streamnet_gdf\n",
+    "    streamnet_gdf.drop(columns=gh.mnsi.MNSI_FIELDS, inplace=True)\n",
     "\n",
     "\n",
-    "    # write GeoParquet files\n",
-    "    tdx_parquet_path = tdx_dir / f\"TDX_streamreach_basins_{tdx_hydro_region}_01.parquet\"\n",
-    "    gdf.to_parquet(tdx_parquet_path, compression='zstd')\n",
-    "    print(f'  File saved: {tdx_parquet_path.name}')\n",
+    "    ## Write GeoParquet files ##\n",
+    "    gdf_dict = {\n",
+    "        'streamnet': streamnet_gdf,\n",
+    "        'streamreach_basins_mnsi': basins_mnsi_gdf,\n",
+    "        'streams_no_basin': streams_no_basin_gdf,\n",
+    "    }\n",
+    "    parquet_paths = []\n",
+    "    for dataset, gdf in gdf_dict.items():\n",
+    "        path = output_dir / f\"TDX_{dataset}_{tdx_hydro_region}_01.parquet\"\n",
+    "        parquet_paths.append(path)\n",
+    "        gdf.to_parquet(path, compression='zstd')\n",
+    "        print(f'  File saved: {path.name}')\n",
     "\n",
-    "    return tdx_parquet_path"
+    "    return parquet_paths"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<module 'global_hydrography.process' from '/Users/aaufdenkampe/Documents/Python/global-hydrography/src/global_hydrography/process.py'>"
+      ]
+     },
+     "execution_count": 61,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "reload(gh.mnsi)\n",
+    "reload(gh.process)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Processing TDXHydroRegion = 7020038340\n",
+      "  Reading: layer = TDX_streamnet_7020038340_01 last updated 2021-12-08\n",
+      "  Computing: modified nested set index\n",
+      "  Reading: layer = basins\n",
+      "  Moving MNSI files from streamnet to basins datasets.\n",
+      "  File saved: TDX_streamnet_7020038340_01.parquet\n",
+      "  File saved: TDX_streamreach_basins_mnsi_7020038340_01.parquet\n",
+      "  File saved: TDX_streams_no_basin_7020038340_01.parquet\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[PosixPath('/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/processed/TDX_streamnet_7020038340_01.parquet'),\n",
+       " PosixPath('/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/processed/TDX_streamreach_basins_mnsi_7020038340_01.parquet'),\n",
+       " PosixPath('/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/processed/TDX_streams_no_basin_7020038340_01.parquet')]"
+      ]
+     },
+     "execution_count": 62,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Try function\n",
+    "process_tdx_streams_basins(\n",
+    "    tdx_dir,\n",
+    "    tdx_dir / 'processed',\n",
+    "    7020038340,\n",
+    "    preprocessor,\n",
+    ")"
    ]
   },
   {

--- a/examples/4_ProcessBasinToParquet.ipynb
+++ b/examples/4_ProcessBasinToParquet.ipynb
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -38,7 +38,42 @@
     "import geopandas as gpd\n",
     "import pandas as pd\n",
     "\n",
+    "import global_hydrography as gh\n",
     "from global_hydrography.preprocess import TDXPreprocessor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['__builtins__',\n",
+       " '__cached__',\n",
+       " '__doc__',\n",
+       " '__file__',\n",
+       " '__loader__',\n",
+       " '__name__',\n",
+       " '__package__',\n",
+       " '__path__',\n",
+       " '__spec__',\n",
+       " 'delineation',\n",
+       " 'io',\n",
+       " 'mnsi',\n",
+       " 'preprocess',\n",
+       " 'process']"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Explore the namespace for global-hydrography modules, functions, etc.\n",
+    "dir(gh)"
    ]
   },
   {
@@ -52,7 +87,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -65,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,7 +113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -89,7 +124,7 @@
        " PosixPath('/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/TDX_streamreach_basins_1020040190_01.gpkg')]"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -114,7 +149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -165,7 +200,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -174,7 +209,7 @@
        "'TDX_streamreach_basins_7020038340_01.gpkg'"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -187,7 +222,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -196,7 +231,7 @@
        "2647.330816"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -208,7 +243,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -232,7 +267,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -241,7 +276,7 @@
        "676.472978"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -253,7 +288,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -366,7 +401,7 @@
        "[140053 rows x 1 columns]"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -380,7 +415,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -401,7 +436,7 @@
        "LINKNO: [[750000001,750000002,750000003,750000004,750000005,...,750071698,750071699,750071700,750071701,750071702],[750071703,750071704,750071705,750071706,750071707,...,750215295,750215296,750215297,750215298,750215299],[750215300,750215301,750215302,750215303,750215304,...,750325343,750325935,750326527,750327119,750327711]]"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -422,7 +457,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -432,7 +467,7 @@
        " PosixPath('/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/TDX_streamnet_7020038340_01_mnsi.parquet')]"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -448,7 +483,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -457,7 +492,7 @@
        "'TDX_streamnet_7020038340_01_mnsi.parquet'"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -469,7 +504,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -514,7 +549,7 @@
        "      dtype='int32', name='LINKNO', length=140097)"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -527,134 +562,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 28,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>DSContArea</th>\n",
-       "      <th>USContArea</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>LINKNO</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>750000000</th>\n",
-       "      <td>9567845.0</td>\n",
-       "      <td>5254867.5</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>750000001</th>\n",
-       "      <td>8768556.0</td>\n",
-       "      <td>4320561.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>750000593</th>\n",
-       "      <td>8466694.0</td>\n",
-       "      <td>4319318.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>750001777</th>\n",
-       "      <td>19939082.0</td>\n",
-       "      <td>18034788.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>750000002</th>\n",
-       "      <td>9120895.0</td>\n",
-       "      <td>5267176.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>...</th>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>750000587</th>\n",
-       "      <td>10233235.0</td>\n",
-       "      <td>7569312.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>750001180</th>\n",
-       "      <td>9136435.0</td>\n",
-       "      <td>4495984.5</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>750001772</th>\n",
-       "      <td>4879280.0</td>\n",
-       "      <td>4387448.5</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>750000588</th>\n",
-       "      <td>5911555.0</td>\n",
-       "      <td>4346421.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>750000589</th>\n",
-       "      <td>5180645.5</td>\n",
-       "      <td>5107666.0</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "<p>140097 rows × 2 columns</p>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "           DSContArea  USContArea\n",
-       "LINKNO                           \n",
-       "750000000   9567845.0   5254867.5\n",
-       "750000001   8768556.0   4320561.0\n",
-       "750000593   8466694.0   4319318.0\n",
-       "750001777  19939082.0  18034788.0\n",
-       "750000002   9120895.0   5267176.0\n",
-       "...               ...         ...\n",
-       "750000587  10233235.0   7569312.0\n",
-       "750001180   9136435.0   4495984.5\n",
-       "750001772   4879280.0   4387448.5\n",
-       "750000588   5911555.0   4346421.0\n",
-       "750000589   5180645.5   5107666.0\n",
-       "\n",
-       "[140097 rows x 2 columns]"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Try merging data\n",
     "basins_gdf = gdf.copy(deep=True)\n",
     "\n",
-    "columns_to_merge = ['DSContArea', 'USContArea']\n",
-    "stream_mnsi_gdf[columns_to_merge]\n"
+    "columns_to_merge = ['DSContArea', 'USContArea']\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -675,7 +595,7 @@
     }
    ],
    "source": [
-    "# Merge confirms that there LINKNO values match\n",
+    "# Merge confirms that their LINKNO values match\n",
     "# Although there are not as many basins as there are stream reaches!\n",
     "pd.merge(\n",
     "    basins_gdf, \n",
@@ -687,164 +607,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>geometry</th>\n",
-       "      <th>DSContArea</th>\n",
-       "      <th>USContArea</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>LINKNO</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>750000000</th>\n",
-       "      <td>None</td>\n",
-       "      <td>9567845.0</td>\n",
-       "      <td>5254867.5</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>750000001</th>\n",
-       "      <td>POLYGON ((-69.71706 46.42639, -69.71572 46.426...</td>\n",
-       "      <td>8768556.0</td>\n",
-       "      <td>4320561.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>750000593</th>\n",
-       "      <td>POLYGON ((-69.70117 46.4495, -69.70106 46.4495...</td>\n",
-       "      <td>8466694.0</td>\n",
-       "      <td>4319318.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>750001777</th>\n",
-       "      <td>POLYGON ((-69.68828 46.41661, -69.68783 46.416...</td>\n",
-       "      <td>19939082.0</td>\n",
-       "      <td>18034788.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>750000002</th>\n",
-       "      <td>POLYGON ((-69.71939 46.39428, -69.71928 46.394...</td>\n",
-       "      <td>9120895.0</td>\n",
-       "      <td>5267176.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>...</th>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>750000587</th>\n",
-       "      <td>POLYGON ((-81.59061 24.64672, -81.5905 24.6467...</td>\n",
-       "      <td>10233235.0</td>\n",
-       "      <td>7569312.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>750001180</th>\n",
-       "      <td>POLYGON ((-81.59872 24.63283, -81.59739 24.632...</td>\n",
-       "      <td>9136435.0</td>\n",
-       "      <td>4495984.5</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>750001772</th>\n",
-       "      <td>POLYGON ((-81.59439 24.61461, -81.59394 24.614...</td>\n",
-       "      <td>4879280.0</td>\n",
-       "      <td>4387448.5</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>750000588</th>\n",
-       "      <td>MULTIPOLYGON (((-81.64961 24.60039, -81.64961 ...</td>\n",
-       "      <td>5911555.0</td>\n",
-       "      <td>4346421.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>750000589</th>\n",
-       "      <td>MULTIPOLYGON (((-81.68106 24.56006, -81.68094 ...</td>\n",
-       "      <td>5180645.5</td>\n",
-       "      <td>5107666.0</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "<p>140097 rows × 3 columns</p>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                                    geometry  DSContArea  \\\n",
-       "LINKNO                                                                     \n",
-       "750000000                                               None   9567845.0   \n",
-       "750000001  POLYGON ((-69.71706 46.42639, -69.71572 46.426...   8768556.0   \n",
-       "750000593  POLYGON ((-69.70117 46.4495, -69.70106 46.4495...   8466694.0   \n",
-       "750001777  POLYGON ((-69.68828 46.41661, -69.68783 46.416...  19939082.0   \n",
-       "750000002  POLYGON ((-69.71939 46.39428, -69.71928 46.394...   9120895.0   \n",
-       "...                                                      ...         ...   \n",
-       "750000587  POLYGON ((-81.59061 24.64672, -81.5905 24.6467...  10233235.0   \n",
-       "750001180  POLYGON ((-81.59872 24.63283, -81.59739 24.632...   9136435.0   \n",
-       "750001772  POLYGON ((-81.59439 24.61461, -81.59394 24.614...   4879280.0   \n",
-       "750000588  MULTIPOLYGON (((-81.64961 24.60039, -81.64961 ...   5911555.0   \n",
-       "750000589  MULTIPOLYGON (((-81.68106 24.56006, -81.68094 ...   5180645.5   \n",
-       "\n",
-       "           USContArea  \n",
-       "LINKNO                 \n",
-       "750000000   5254867.5  \n",
-       "750000001   4320561.0  \n",
-       "750000593   4319318.0  \n",
-       "750001777  18034788.0  \n",
-       "750000002   5267176.0  \n",
-       "...               ...  \n",
-       "750000587   7569312.0  \n",
-       "750001180   4495984.5  \n",
-       "750001772   4387448.5  \n",
-       "750000588   4346421.0  \n",
-       "750000589   5107666.0  \n",
-       "\n",
-       "[140097 rows x 3 columns]"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "pd.merge(basins_gdf, stream_mnsi_gdf[columns_to_merge], how='right', on='LINKNO')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "34 ms ± 1.86 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "33.2 ms ± 973 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -852,6 +622,166 @@
     "%%timeit\n",
     "# Merges are very fast!\n",
     "pd.merge(basins_gdf, stream_mnsi_gdf[columns_to_merge], how='right', on='LINKNO')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'geopandas.geodataframe.GeoDataFrame'>\n",
+      "Index: 140053 entries, 750000001 to 750327711\n",
+      "Data columns (total 2 columns):\n",
+      " #   Column    Non-Null Count   Dtype   \n",
+      "---  ------    --------------   -----   \n",
+      " 0   ROOT_ID   140053 non-null  int32   \n",
+      " 1   geometry  140053 non-null  geometry\n",
+      "dtypes: geometry(1), int32(1)\n",
+      "memory usage: 2.7 MB\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Pandas insert allows placement of column at a specified location.\n",
+    "ROOT = \"ROOT_ID\"\n",
+    "basins_gdf.insert(0, ROOT, stream_mnsi_gdf[ROOT])\n",
+    "basins_gdf.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 5.64 ms, sys: 1.13 ms, total: 6.77 ms\n",
+      "Wall time: 5.03 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "# Insert is even faster!\n",
+    "DISCOVER = \"DISCOVER_TIME\"\n",
+    "basins_gdf.insert(0, DISCOVER, stream_mnsi_gdf[DISCOVER])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Alternate: Create Basins with MNSI\n",
+    "\n",
+    "To only read the basin's file for delinating the upstream watershed boundary.\n",
+    "\n",
+    "Using new functions in source directory to streamline production."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<module 'global_hydrography.process' from '/Users/aaufdenkampe/Documents/Python/global-hydrography/src/global_hydrography/process.py'>"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "reload(gh.process)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# define a helper function for the operation\n",
+    "def process_tdx_streams_basins(\n",
+    "    source_dir: Path,\n",
+    "    processed_dir: Path,\n",
+    "    tdx_hydro_region: int, \n",
+    "    preprocessor:TDXPreprocessor\n",
+    ") -> None:\n",
+    "    \n",
+    "    print (f\"Processing TDXHydroRegion = {tdx_hydro_region}\")\n",
+    "\n",
+    "    # Get file paths\n",
+    "    streamnet_file, basins_file = gh.process.select_tdx_files(\n",
+    "        source_dir, tdx_hydro_region,'.gpkg')\n",
+    "    \n",
+    "\n",
+    "    ## Process streamnet file ##\n",
+    "    # get streamnet file metadata\n",
+    "    streamnet_info = pyogrio.read_info(streamnet_file, layer=0)\n",
+    "    print(f\"  Reading: layer = {streamnet_info['layer_name']} last updated \n",
+    "          {streamnet_info['layer_metadata']['DBF_DATE_LAST_UPDATE']}\")\n",
+    "    \n",
+    "    # open streamnet file as GeoDataFrame\n",
+    "    streamnet_gdf = gpd.read_file(streamnet_file, engine='pyogrio', layer=0, use_arrow=True)\n",
+    "\n",
+    "    # apply preprocessing to make linkno globally unique\n",
+    "    preprocessor.tdx_to_global_linkno(streamnet_gdf, tdx_hydro_region)\n",
+    "\n",
+    "    # apply preprocessing to make drop columns with no value\n",
+    "    preprocessor.tdx_drop_useless_columns(streamnet_gdf)\n",
+    "\n",
+    "    # compute the modified nested set index\n",
+    "    streamnet_gdf = gh.mnsi.modified_nest_set_index(streamnet_gdf)\n",
+    "    print('  Computed: modified nested set index')\n",
+    "\n",
+    "    # Set 'LINKNO' as index, to facilitate selection\n",
+    "    streamnet_gdf.set_index('LINKNO', inplace=True)\n",
+    "\n",
+    "\n",
+    "    ## Process basins file ##\n",
+    "    # get basins file metadata\n",
+    "    basins_info = pyogrio.read_info(basins_file, layer=0)\n",
+    "    print(f\"  Reading: layer = {basins_info['layer_name']}\")\n",
+    "\n",
+    "    # open basins file as GeoDataFrame\n",
+    "    basins_gdf = gpd.read_file(basins_file, engine='pyogrio', layer=0, use_arrow=True)\n",
+    "\n",
+    "    # Rename 'streamID' to 'LINKNO' to facilitate interoperability \n",
+    "    # with streamnet files\n",
+    "    basins_gdf.rename(columns={'streamID':'LINKNO'}, inplace=True)\n",
+    "    \n",
+    "    # apply preprocessing to make linkno globally unique\n",
+    "    preprocessor.tdx_to_global_linkno(basins_gdf, tdx_hydro_region)\n",
+    "\n",
+    "    # Set 'LINKNO' as index, to facilitate selection\n",
+    "    basins_gdf.set_index('LINKNO', inplace=True)\n",
+    "\n",
+    "    \n",
+    "    ## Move MNSI fields from streamnet to basins\n",
+    "    DISCOVER = \"DISCOVER_TIME\"\n",
+    "    FINISH = \"FINISH_TIME\"\n",
+    "    ROOT = \"ROOT_ID\"\n",
+    "    # at column locations right after other LINK info\n",
+    "    for f in (FINISH, DISCOVER, ROOT):\n",
+    "        basins_gdf.insert(0, f, None)\n",
+    "\n",
+    "\n",
+    "    # write GeoParquet files\n",
+    "    tdx_parquet_path = tdx_dir / f\"TDX_streamreach_basins_{tdx_hydro_region}_01.parquet\"\n",
+    "    gdf.to_parquet(tdx_parquet_path, compression='zstd')\n",
+    "    print(f'  File saved: {tdx_parquet_path.name}')\n",
+    "\n",
+    "    return tdx_parquet_path"
    ]
   },
   {

--- a/sandbox/explore_data_sources.ipynb
+++ b/sandbox/explore_data_sources.ipynb
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
@@ -86,11 +86,11 @@
       "application/vnd.holoviews_exec.v0+json": "",
       "text/html": [
        "<div id='p1009'>\n",
-       "  <div id=\"a3037c62-b580-4581-afca-afa401ccff93\" data-root-id=\"p1009\" style=\"display: contents;\"></div>\n",
+       "  <div id=\"efbb3d88-e6b6-4193-8954-a7acfac15e94\" data-root-id=\"p1009\" style=\"display: contents;\"></div>\n",
        "</div>\n",
        "<script type=\"application/javascript\">(function(root) {\n",
-       "  var docs_json = {\"ff60d5df-9207-4b49-aa9d-444837184e2b\":{\"version\":\"3.4.1\",\"title\":\"Bokeh Application\",\"roots\":[{\"type\":\"object\",\"name\":\"panel.models.browser.BrowserInfo\",\"id\":\"p1009\"},{\"type\":\"object\",\"name\":\"panel.models.comm_manager.CommManager\",\"id\":\"p1010\",\"attributes\":{\"plot_id\":\"p1009\",\"comm_id\":\"a754bb5e7a674e8b9cc88ce6a78dacd5\",\"client_comm_id\":\"308905c07f7643cabef355e89d7b809d\"}}],\"defs\":[{\"type\":\"model\",\"name\":\"ReactiveHTML1\"},{\"type\":\"model\",\"name\":\"FlexBox1\",\"properties\":[{\"name\":\"align_content\",\"kind\":\"Any\",\"default\":\"flex-start\"},{\"name\":\"align_items\",\"kind\":\"Any\",\"default\":\"flex-start\"},{\"name\":\"flex_direction\",\"kind\":\"Any\",\"default\":\"row\"},{\"name\":\"flex_wrap\",\"kind\":\"Any\",\"default\":\"wrap\"},{\"name\":\"gap\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"justify_content\",\"kind\":\"Any\",\"default\":\"flex-start\"}]},{\"type\":\"model\",\"name\":\"FloatPanel1\",\"properties\":[{\"name\":\"config\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}},{\"name\":\"contained\",\"kind\":\"Any\",\"default\":true},{\"name\":\"position\",\"kind\":\"Any\",\"default\":\"right-top\"},{\"name\":\"offsetx\",\"kind\":\"Any\",\"default\":null},{\"name\":\"offsety\",\"kind\":\"Any\",\"default\":null},{\"name\":\"theme\",\"kind\":\"Any\",\"default\":\"primary\"},{\"name\":\"status\",\"kind\":\"Any\",\"default\":\"normalized\"}]},{\"type\":\"model\",\"name\":\"GridStack1\",\"properties\":[{\"name\":\"mode\",\"kind\":\"Any\",\"default\":\"warn\"},{\"name\":\"ncols\",\"kind\":\"Any\",\"default\":null},{\"name\":\"nrows\",\"kind\":\"Any\",\"default\":null},{\"name\":\"allow_resize\",\"kind\":\"Any\",\"default\":true},{\"name\":\"allow_drag\",\"kind\":\"Any\",\"default\":true},{\"name\":\"state\",\"kind\":\"Any\",\"default\":[]}]},{\"type\":\"model\",\"name\":\"drag1\",\"properties\":[{\"name\":\"slider_width\",\"kind\":\"Any\",\"default\":5},{\"name\":\"slider_color\",\"kind\":\"Any\",\"default\":\"black\"},{\"name\":\"value\",\"kind\":\"Any\",\"default\":50}]},{\"type\":\"model\",\"name\":\"click1\",\"properties\":[{\"name\":\"terminal_output\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"debug_name\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"clears\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"FastWrapper1\",\"properties\":[{\"name\":\"object\",\"kind\":\"Any\",\"default\":null},{\"name\":\"style\",\"kind\":\"Any\",\"default\":null}]},{\"type\":\"model\",\"name\":\"NotificationAreaBase1\",\"properties\":[{\"name\":\"js_events\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}},{\"name\":\"position\",\"kind\":\"Any\",\"default\":\"bottom-right\"},{\"name\":\"_clear\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"NotificationArea1\",\"properties\":[{\"name\":\"js_events\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}},{\"name\":\"notifications\",\"kind\":\"Any\",\"default\":[]},{\"name\":\"position\",\"kind\":\"Any\",\"default\":\"bottom-right\"},{\"name\":\"_clear\",\"kind\":\"Any\",\"default\":0},{\"name\":\"types\",\"kind\":\"Any\",\"default\":[{\"type\":\"map\",\"entries\":[[\"type\",\"warning\"],[\"background\",\"#ffc107\"],[\"icon\",{\"type\":\"map\",\"entries\":[[\"className\",\"fas fa-exclamation-triangle\"],[\"tagName\",\"i\"],[\"color\",\"white\"]]}]]},{\"type\":\"map\",\"entries\":[[\"type\",\"info\"],[\"background\",\"#007bff\"],[\"icon\",{\"type\":\"map\",\"entries\":[[\"className\",\"fas fa-info-circle\"],[\"tagName\",\"i\"],[\"color\",\"white\"]]}]]}]}]},{\"type\":\"model\",\"name\":\"Notification\",\"properties\":[{\"name\":\"background\",\"kind\":\"Any\",\"default\":null},{\"name\":\"duration\",\"kind\":\"Any\",\"default\":3000},{\"name\":\"icon\",\"kind\":\"Any\",\"default\":null},{\"name\":\"message\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"notification_type\",\"kind\":\"Any\",\"default\":null},{\"name\":\"_destroyed\",\"kind\":\"Any\",\"default\":false}]},{\"type\":\"model\",\"name\":\"TemplateActions1\",\"properties\":[{\"name\":\"open_modal\",\"kind\":\"Any\",\"default\":0},{\"name\":\"close_modal\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"BootstrapTemplateActions1\",\"properties\":[{\"name\":\"open_modal\",\"kind\":\"Any\",\"default\":0},{\"name\":\"close_modal\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"TemplateEditor1\",\"properties\":[{\"name\":\"layout\",\"kind\":\"Any\",\"default\":[]}]},{\"type\":\"model\",\"name\":\"MaterialTemplateActions1\",\"properties\":[{\"name\":\"open_modal\",\"kind\":\"Any\",\"default\":0},{\"name\":\"close_modal\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"copy_to_clipboard1\",\"properties\":[{\"name\":\"fill\",\"kind\":\"Any\",\"default\":\"none\"},{\"name\":\"value\",\"kind\":\"Any\",\"default\":null}]}]}};\n",
-       "  var render_items = [{\"docid\":\"ff60d5df-9207-4b49-aa9d-444837184e2b\",\"roots\":{\"p1009\":\"a3037c62-b580-4581-afca-afa401ccff93\"},\"root_ids\":[\"p1009\"]}];\n",
+       "  var docs_json = {\"2974624b-010d-4d8d-9b41-b2a75cd0c07c\":{\"version\":\"3.4.1\",\"title\":\"Bokeh Application\",\"roots\":[{\"type\":\"object\",\"name\":\"panel.models.browser.BrowserInfo\",\"id\":\"p1009\"},{\"type\":\"object\",\"name\":\"panel.models.comm_manager.CommManager\",\"id\":\"p1010\",\"attributes\":{\"plot_id\":\"p1009\",\"comm_id\":\"83e03c8817c345ed8ed6259c23f062f0\",\"client_comm_id\":\"dcbb8e80dd214952b147d86a0cf411a2\"}}],\"defs\":[{\"type\":\"model\",\"name\":\"ReactiveHTML1\"},{\"type\":\"model\",\"name\":\"FlexBox1\",\"properties\":[{\"name\":\"align_content\",\"kind\":\"Any\",\"default\":\"flex-start\"},{\"name\":\"align_items\",\"kind\":\"Any\",\"default\":\"flex-start\"},{\"name\":\"flex_direction\",\"kind\":\"Any\",\"default\":\"row\"},{\"name\":\"flex_wrap\",\"kind\":\"Any\",\"default\":\"wrap\"},{\"name\":\"gap\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"justify_content\",\"kind\":\"Any\",\"default\":\"flex-start\"}]},{\"type\":\"model\",\"name\":\"FloatPanel1\",\"properties\":[{\"name\":\"config\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}},{\"name\":\"contained\",\"kind\":\"Any\",\"default\":true},{\"name\":\"position\",\"kind\":\"Any\",\"default\":\"right-top\"},{\"name\":\"offsetx\",\"kind\":\"Any\",\"default\":null},{\"name\":\"offsety\",\"kind\":\"Any\",\"default\":null},{\"name\":\"theme\",\"kind\":\"Any\",\"default\":\"primary\"},{\"name\":\"status\",\"kind\":\"Any\",\"default\":\"normalized\"}]},{\"type\":\"model\",\"name\":\"GridStack1\",\"properties\":[{\"name\":\"mode\",\"kind\":\"Any\",\"default\":\"warn\"},{\"name\":\"ncols\",\"kind\":\"Any\",\"default\":null},{\"name\":\"nrows\",\"kind\":\"Any\",\"default\":null},{\"name\":\"allow_resize\",\"kind\":\"Any\",\"default\":true},{\"name\":\"allow_drag\",\"kind\":\"Any\",\"default\":true},{\"name\":\"state\",\"kind\":\"Any\",\"default\":[]}]},{\"type\":\"model\",\"name\":\"drag1\",\"properties\":[{\"name\":\"slider_width\",\"kind\":\"Any\",\"default\":5},{\"name\":\"slider_color\",\"kind\":\"Any\",\"default\":\"black\"},{\"name\":\"value\",\"kind\":\"Any\",\"default\":50}]},{\"type\":\"model\",\"name\":\"click1\",\"properties\":[{\"name\":\"terminal_output\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"debug_name\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"clears\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"FastWrapper1\",\"properties\":[{\"name\":\"object\",\"kind\":\"Any\",\"default\":null},{\"name\":\"style\",\"kind\":\"Any\",\"default\":null}]},{\"type\":\"model\",\"name\":\"NotificationAreaBase1\",\"properties\":[{\"name\":\"js_events\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}},{\"name\":\"position\",\"kind\":\"Any\",\"default\":\"bottom-right\"},{\"name\":\"_clear\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"NotificationArea1\",\"properties\":[{\"name\":\"js_events\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}},{\"name\":\"notifications\",\"kind\":\"Any\",\"default\":[]},{\"name\":\"position\",\"kind\":\"Any\",\"default\":\"bottom-right\"},{\"name\":\"_clear\",\"kind\":\"Any\",\"default\":0},{\"name\":\"types\",\"kind\":\"Any\",\"default\":[{\"type\":\"map\",\"entries\":[[\"type\",\"warning\"],[\"background\",\"#ffc107\"],[\"icon\",{\"type\":\"map\",\"entries\":[[\"className\",\"fas fa-exclamation-triangle\"],[\"tagName\",\"i\"],[\"color\",\"white\"]]}]]},{\"type\":\"map\",\"entries\":[[\"type\",\"info\"],[\"background\",\"#007bff\"],[\"icon\",{\"type\":\"map\",\"entries\":[[\"className\",\"fas fa-info-circle\"],[\"tagName\",\"i\"],[\"color\",\"white\"]]}]]}]}]},{\"type\":\"model\",\"name\":\"Notification\",\"properties\":[{\"name\":\"background\",\"kind\":\"Any\",\"default\":null},{\"name\":\"duration\",\"kind\":\"Any\",\"default\":3000},{\"name\":\"icon\",\"kind\":\"Any\",\"default\":null},{\"name\":\"message\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"notification_type\",\"kind\":\"Any\",\"default\":null},{\"name\":\"_destroyed\",\"kind\":\"Any\",\"default\":false}]},{\"type\":\"model\",\"name\":\"TemplateActions1\",\"properties\":[{\"name\":\"open_modal\",\"kind\":\"Any\",\"default\":0},{\"name\":\"close_modal\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"BootstrapTemplateActions1\",\"properties\":[{\"name\":\"open_modal\",\"kind\":\"Any\",\"default\":0},{\"name\":\"close_modal\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"TemplateEditor1\",\"properties\":[{\"name\":\"layout\",\"kind\":\"Any\",\"default\":[]}]},{\"type\":\"model\",\"name\":\"MaterialTemplateActions1\",\"properties\":[{\"name\":\"open_modal\",\"kind\":\"Any\",\"default\":0},{\"name\":\"close_modal\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"copy_to_clipboard1\",\"properties\":[{\"name\":\"fill\",\"kind\":\"Any\",\"default\":\"none\"},{\"name\":\"value\",\"kind\":\"Any\",\"default\":null}]}]}};\n",
+       "  var render_items = [{\"docid\":\"2974624b-010d-4d8d-9b41-b2a75cd0c07c\",\"roots\":{\"p1009\":\"efbb3d88-e6b6-4193-8954-a7acfac15e94\"},\"root_ids\":[\"p1009\"]}];\n",
        "  var docs = Object.values(docs_json)\n",
        "  if (!docs) {\n",
        "    return\n",
@@ -278,7 +278,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -287,7 +287,7 @@
        "'hydrography'"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -308,7 +308,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -317,7 +317,7 @@
        "PosixPath('/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp')"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -341,7 +341,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -352,7 +352,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -361,17 +361,23 @@
        "['/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/global_hydrography.qgz',\n",
        " '/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/geoglows-v2',\n",
        " '/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/.DS_Store',\n",
+       " '/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/test_downcast_gdf.parquet',\n",
        " '/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/test_gdf.parquet',\n",
        " '/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/test_pa_gdf.parquet',\n",
+       " '/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/test_ga_pa_df.parquet',\n",
+       " '/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/test_gpd_gdf.parquet',\n",
+       " '/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/test_pa_geo_df.parquet',\n",
        " '/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/io_10m_annual_lulc',\n",
        " '/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nhdplus2',\n",
        " '/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/hydrobasins',\n",
+       " '/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/test_gpd_gdf.gpkg',\n",
        " '/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga',\n",
        " '/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/test_pa_df.parquet',\n",
+       " '/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/test_downscaled_gdf.parquet',\n",
        " '/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/test_df.parquet']"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -383,26 +389,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "{'name': '/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/global_hydrography.qgz',\n",
-       " 'size': 136080,\n",
+       " 'size': 136499,\n",
        " 'type': 'file',\n",
-       " 'created': 1715865642.721543,\n",
+       " 'created': 1721235118.8378024,\n",
        " 'islink': False,\n",
        " 'mode': 33188,\n",
        " 'uid': 502,\n",
        " 'gid': 20,\n",
-       " 'mtime': 1715865642.721089,\n",
-       " 'ino': 270190000,\n",
+       " 'mtime': 1721235118.8372164,\n",
+       " 'ino': 301838904,\n",
        " 'nlink': 1}"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -445,11 +451,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
     "# HydroBASINS Identifier & Region (Section 3.1 in Tech Docs)\n",
+    "# 2-character identifier used for file naming\n",
     "hybas_region_dict = {\n",
     "    'af': 'Africa',\n",
     "    'ar': 'North American Arctic',\n",
@@ -457,14 +464,36 @@
     "    'au': 'Australia and Oceania',\n",
     "    'eu': 'Europe and Middle East',\n",
     "    'gr': 'Greenland',\n",
-    "    'na': 'North America and Caribbean sa South America',\n",
+    "    'na': 'North America and Caribbean',\n",
+    "    'sa': 'South America',\n",
     "    'si': 'Siberia',\n",
     "}"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# HydroBASINS Region Numbers (Section 3.1 in Tech Docs)\n",
+    "# Single digit prefix for HYBAS_ID values at all levels\n",
+    "hybas_region_number_dict = {\n",
+    "    1: 'Africa',\n",
+    "    2: 'Europe and Middle East',\n",
+    "    3: 'Siberia',\n",
+    "    4: 'Central and South-East Asia',\n",
+    "    5: 'Australia and Oceania',\n",
+    "    6: 'South America',\n",
+    "    7: 'North America and Caribbean',\n",
+    "    8: 'North American Arctic',\n",
+    "    9: 'Greenland',\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -476,7 +505,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -488,7 +517,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -497,7 +526,7 @@
        "'hybas_na_lev02_v1c.zip'"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -519,7 +548,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -528,7 +557,7 @@
        "True"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -541,22 +570,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 4.34 ms, sys: 2.48 ms, total: 6.82 ms\n",
-      "Wall time: 600 ms\n"
+      "CPU times: user 4.52 ms, sys: 1.82 ms, total: 6.34 ms\n",
+      "Wall time: 76.1 ms\n"
      ]
     },
     {
@@ -569,20 +591,20 @@
        " 'type': 'file'}"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "%%time\n",
-    "# getting remot info is fast\n",
+    "# getting remote info is fast\n",
     "hybas_fs.info(hybas_filepath)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -592,7 +614,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -600,9 +622,9 @@
      "output_type": "stream",
      "text": [
       "We have it!\n",
-      "/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/hydrobasins/hybas_si_lev04_v1c.zip True\n",
-      "CPU times: user 568 µs, sys: 349 µs, total: 917 µs\n",
-      "Wall time: 737 µs\n"
+      "/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/hydrobasins/hybas_na_lev02_v1c.zip True\n",
+      "CPU times: user 352 µs, sys: 179 µs, total: 531 µs\n",
+      "Wall time: 448 µs\n"
      ]
     }
    ],
@@ -628,30 +650,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "hybas_af_lev04_v1c.zip True\n",
-      "hybas_ar_lev04_v1c.zip True\n",
-      "hybas_as_lev04_v1c.zip True\n",
-      "hybas_au_lev04_v1c.zip True\n",
-      "hybas_eu_lev04_v1c.zip True\n",
-      "hybas_gr_lev04_v1c.zip True\n",
-      "hybas_na_lev04_v1c.zip True\n",
-      "hybas_si_lev04_v1c.zip True\n",
-      "CPU times: user 507 ms, sys: 295 ms, total: 802 ms\n",
-      "Wall time: 14.6 s\n"
+      "hybas_af_lev02_v1c.zip True\n",
+      "hybas_ar_lev02_v1c.zip True\n",
+      "hybas_as_lev02_v1c.zip True\n",
+      "hybas_au_lev02_v1c.zip True\n",
+      "hybas_eu_lev02_v1c.zip True\n",
+      "hybas_gr_lev02_v1c.zip True\n",
+      "hybas_na_lev02_v1c.zip True\n",
+      "hybas_sa_lev02_v1c.zip True\n",
+      "hybas_si_lev02_v1c.zip True\n",
+      "CPU times: user 113 ms, sys: 85 ms, total: 198 ms\n",
+      "Wall time: 1.31 s\n"
      ]
     }
    ],
    "source": [
     "%%time\n",
     "# Get all continents (level 2).\n",
-    "level = '04'\n",
+    "level = '02'\n",
     "for region in hybas_region_dict.keys():\n",
     "    hybas_filename = f'hybas_{region}_lev{level}_v1c.zip'\n",
     "    hybas_filepath = f'{hybas_url}/{hybas_filename}'\n",
@@ -661,7 +684,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -686,14 +709,17 @@
       "Greenland\n",
       "   [['hybas_gr_lev02_v1c' 'Polygon']]\n",
       "   [91]\n",
-      "North America and Caribbean sa South America\n",
+      "North America and Caribbean\n",
       "   [['hybas_na_lev02_v1c' 'Polygon']]\n",
       "   [77 78 71 72 73 74 75 76]\n",
+      "South America\n",
+      "   [['hybas_sa_lev02_v1c' 'Polygon']]\n",
+      "   [61 62 63 64 65 66 67]\n",
       "Siberia\n",
       "   [['hybas_si_lev02_v1c' 'Polygon']]\n",
       "   [31 32 33 34 35 36]\n",
-      "CPU times: user 544 ms, sys: 268 ms, total: 811 ms\n",
-      "Wall time: 1.2 s\n"
+      "CPU times: user 615 ms, sys: 67.5 ms, total: 682 ms\n",
+      "Wall time: 832 ms\n"
      ]
     }
    ],
@@ -716,7 +742,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -728,7 +754,7 @@
        "      dtype='object')"
       ]
      },
-     "execution_count": 63,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -747,27 +773,195 @@
      "output_type": "stream",
      "text": [
       "<class 'geopandas.geodataframe.GeoDataFrame'>\n",
-      "Index: 55 entries, 1020000010 to 3020024310\n",
-      "Data columns (total 13 columns):\n",
+      "RangeIndex: 62 entries, 0 to 61\n",
+      "Data columns (total 14 columns):\n",
       " #   Column     Non-Null Count  Dtype   \n",
       "---  ------     --------------  -----   \n",
-      " 0   NEXT_DOWN  55 non-null     int64   \n",
-      " 1   NEXT_SINK  55 non-null     int64   \n",
-      " 2   MAIN_BAS   55 non-null     int64   \n",
-      " 3   DIST_SINK  55 non-null     float64 \n",
-      " 4   DIST_MAIN  55 non-null     float64 \n",
-      " 5   SUB_AREA   55 non-null     float64 \n",
-      " 6   UP_AREA    55 non-null     float64 \n",
-      " 7   PFAF_ID    55 non-null     int32   \n",
-      " 8   ENDO       55 non-null     int32   \n",
-      " 9   COAST      55 non-null     int32   \n",
-      " 10  ORDER      55 non-null     int32   \n",
-      " 11  SORT       55 non-null     int64   \n",
-      " 12  geometry   55 non-null     geometry\n",
-      "dtypes: float64(4), geometry(1), int32(4), int64(4)\n",
-      "memory usage: 5.2 KB\n"
+      " 0   HYBAS_ID   62 non-null     int64   \n",
+      " 1   NEXT_DOWN  62 non-null     int64   \n",
+      " 2   NEXT_SINK  62 non-null     int64   \n",
+      " 3   MAIN_BAS   62 non-null     int64   \n",
+      " 4   DIST_SINK  62 non-null     float64 \n",
+      " 5   DIST_MAIN  62 non-null     float64 \n",
+      " 6   SUB_AREA   62 non-null     float64 \n",
+      " 7   UP_AREA    62 non-null     float64 \n",
+      " 8   PFAF_ID    62 non-null     int32   \n",
+      " 9   ENDO       62 non-null     int32   \n",
+      " 10  COAST      62 non-null     int32   \n",
+      " 11  ORDER      62 non-null     int32   \n",
+      " 12  SORT       62 non-null     int64   \n",
+      " 13  geometry   62 non-null     geometry\n",
+      "dtypes: float64(4), geometry(1), int32(4), int64(5)\n",
+      "memory usage: 5.9 KB\n"
      ]
     },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>HYBAS_ID</th>\n",
+       "      <th>NEXT_DOWN</th>\n",
+       "      <th>NEXT_SINK</th>\n",
+       "      <th>MAIN_BAS</th>\n",
+       "      <th>DIST_SINK</th>\n",
+       "      <th>DIST_MAIN</th>\n",
+       "      <th>SUB_AREA</th>\n",
+       "      <th>UP_AREA</th>\n",
+       "      <th>PFAF_ID</th>\n",
+       "      <th>ENDO</th>\n",
+       "      <th>COAST</th>\n",
+       "      <th>ORDER</th>\n",
+       "      <th>SORT</th>\n",
+       "      <th>geometry</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1020000010</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1020000010</td>\n",
+       "      <td>1020000010</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>3258330.6</td>\n",
+       "      <td>3258330.6</td>\n",
+       "      <td>11</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>MULTIPOLYGON (((33.67778 27.62917, 33.67119 27...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1020011530</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1020011530</td>\n",
+       "      <td>1020011530</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>4660080.9</td>\n",
+       "      <td>4660080.9</td>\n",
+       "      <td>12</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2</td>\n",
+       "      <td>MULTIPOLYGON (((34.80278 -19.81667, 34.79279 -...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1020018110</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1020018110</td>\n",
+       "      <td>1020018110</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>4900405.1</td>\n",
+       "      <td>4900405.1</td>\n",
+       "      <td>13</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>3</td>\n",
+       "      <td>MULTIPOLYGON (((5.64444 -1.47083, 5.62972 -1.4...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1020021940</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1020021940</td>\n",
+       "      <td>1020021940</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>4046600.5</td>\n",
+       "      <td>4046600.5</td>\n",
+       "      <td>14</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>4</td>\n",
+       "      <td>MULTIPOLYGON (((0.97778 5.9875, 0.97022 5.9884...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>1020027430</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1020027430</td>\n",
+       "      <td>1020027430</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>6923559.6</td>\n",
+       "      <td>6923559.6</td>\n",
+       "      <td>15</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>5</td>\n",
+       "      <td>MULTIPOLYGON (((23.28611 32.22083, 23.28133 32...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     HYBAS_ID  NEXT_DOWN   NEXT_SINK    MAIN_BAS  DIST_SINK  DIST_MAIN  \\\n",
+       "0  1020000010          0  1020000010  1020000010        0.0        0.0   \n",
+       "1  1020011530          0  1020011530  1020011530        0.0        0.0   \n",
+       "2  1020018110          0  1020018110  1020018110        0.0        0.0   \n",
+       "3  1020021940          0  1020021940  1020021940        0.0        0.0   \n",
+       "4  1020027430          0  1020027430  1020027430        0.0        0.0   \n",
+       "\n",
+       "    SUB_AREA    UP_AREA  PFAF_ID  ENDO  COAST  ORDER  SORT  \\\n",
+       "0  3258330.6  3258330.6       11     0      1      0     1   \n",
+       "1  4660080.9  4660080.9       12     0      1      0     2   \n",
+       "2  4900405.1  4900405.1       13     0      1      0     3   \n",
+       "3  4046600.5  4046600.5       14     0      1      0     4   \n",
+       "4  6923559.6  6923559.6       15     0      1      0     5   \n",
+       "\n",
+       "                                            geometry  \n",
+       "0  MULTIPOLYGON (((33.67778 27.62917, 33.67119 27...  \n",
+       "1  MULTIPOLYGON (((34.80278 -19.81667, 34.79279 -...  \n",
+       "2  MULTIPOLYGON (((5.64444 -1.47083, 5.62972 -1.4...  \n",
+       "3  MULTIPOLYGON (((0.97778 5.9875, 0.97022 5.9884...  \n",
+       "4  MULTIPOLYGON (((23.28611 32.22083, 23.28133 32...  "
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Concatenate the GeoDataFrames, which unfortuantly requires converting to Pandas and back\n",
+    "hybas_all_lev02_gdf = gpd.GeoDataFrame(pd.concat(gdf_list, ignore_index=True))\n",
+    "hybas_all_lev02_gdf.info()\n",
+    "hybas_all_lev02_gdf.head()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
     {
      "data": {
       "text/plain": [
@@ -784,20 +978,53 @@
        "- Prime Meridian: Greenwich"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "# Concatenate the GeoDataFrames, which unfortuantly requires converting to Pandas and back\n",
-    "hybas_all_lev02_gdf = gpd.GeoDataFrame(pd.concat(gdf_list, ignore_index=True))\n",
     "hybas_all_lev02_gdf.crs"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False    62\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Do any have upstream basins?\n",
+    "(hybas_all_lev02_gdf.MAIN_BAS != hybas_all_lev02_gdf.HYBAS_ID).value_counts()\n",
+    "# NO! That's good news."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hybas_all_lev02_gdf.to_parquet(\n",
+    "    hybas_dir / 'hybas_all_lev02_gdf.parquet',\n",
+    "    compression='zstd',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -821,6 +1048,7 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
+       "      <th>HYBAS_ID</th>\n",
        "      <th>NEXT_DOWN</th>\n",
        "      <th>NEXT_SINK</th>\n",
        "      <th>MAIN_BAS</th>\n",
@@ -835,42 +1063,11 @@
        "      <th>SORT</th>\n",
        "      <th>geometry</th>\n",
        "    </tr>\n",
-       "    <tr>\n",
-       "      <th>HYBAS_ID</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>1020000010</th>\n",
-       "      <td>0</td>\n",
-       "      <td>1020000010</td>\n",
-       "      <td>1020000010</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>3258330.6</td>\n",
-       "      <td>3258330.6</td>\n",
-       "      <td>11</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1</td>\n",
-       "      <td>MULTIPOLYGON (((33.67778 27.62917, 33.67119 27...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1020011530</th>\n",
+       "      <th>1</th>\n",
+       "      <td>1020011530</td>\n",
        "      <td>0</td>\n",
        "      <td>1020011530</td>\n",
        "      <td>1020011530</td>\n",
@@ -885,136 +1082,28 @@
        "      <td>2</td>\n",
        "      <td>MULTIPOLYGON (((34.80278 -19.81667, 34.79279 -...</td>\n",
        "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1020018110</th>\n",
-       "      <td>0</td>\n",
-       "      <td>1020018110</td>\n",
-       "      <td>1020018110</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>4900405.1</td>\n",
-       "      <td>4900405.1</td>\n",
-       "      <td>13</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1</td>\n",
-       "      <td>0</td>\n",
-       "      <td>3</td>\n",
-       "      <td>MULTIPOLYGON (((5.64444 -1.47083, 5.62972 -1.4...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1020021940</th>\n",
-       "      <td>0</td>\n",
-       "      <td>1020021940</td>\n",
-       "      <td>1020021940</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>4046600.5</td>\n",
-       "      <td>4046600.5</td>\n",
-       "      <td>14</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1</td>\n",
-       "      <td>0</td>\n",
-       "      <td>4</td>\n",
-       "      <td>MULTIPOLYGON (((0.97778 5.98750, 0.97022 5.988...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1020027430</th>\n",
-       "      <td>0</td>\n",
-       "      <td>1020027430</td>\n",
-       "      <td>1020027430</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>6923559.6</td>\n",
-       "      <td>6923559.6</td>\n",
-       "      <td>15</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1</td>\n",
-       "      <td>0</td>\n",
-       "      <td>5</td>\n",
-       "      <td>MULTIPOLYGON (((23.28611 32.22083, 23.28133 32...</td>\n",
-       "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "            NEXT_DOWN   NEXT_SINK    MAIN_BAS  DIST_SINK  DIST_MAIN  \\\n",
-       "HYBAS_ID                                                              \n",
-       "1020000010          0  1020000010  1020000010        0.0        0.0   \n",
-       "1020011530          0  1020011530  1020011530        0.0        0.0   \n",
-       "1020018110          0  1020018110  1020018110        0.0        0.0   \n",
-       "1020021940          0  1020021940  1020021940        0.0        0.0   \n",
-       "1020027430          0  1020027430  1020027430        0.0        0.0   \n",
+       "     HYBAS_ID  NEXT_DOWN   NEXT_SINK    MAIN_BAS  DIST_SINK  DIST_MAIN  \\\n",
+       "1  1020011530          0  1020011530  1020011530        0.0        0.0   \n",
        "\n",
-       "             SUB_AREA    UP_AREA  PFAF_ID  ENDO  COAST  ORDER  SORT  \\\n",
-       "HYBAS_ID                                                              \n",
-       "1020000010  3258330.6  3258330.6       11     0      1      0     1   \n",
-       "1020011530  4660080.9  4660080.9       12     0      1      0     2   \n",
-       "1020018110  4900405.1  4900405.1       13     0      1      0     3   \n",
-       "1020021940  4046600.5  4046600.5       14     0      1      0     4   \n",
-       "1020027430  6923559.6  6923559.6       15     0      1      0     5   \n",
+       "    SUB_AREA    UP_AREA  PFAF_ID  ENDO  COAST  ORDER  SORT  \\\n",
+       "1  4660080.9  4660080.9       12     0      1      0     2   \n",
        "\n",
-       "                                                     geometry  \n",
-       "HYBAS_ID                                                       \n",
-       "1020000010  MULTIPOLYGON (((33.67778 27.62917, 33.67119 27...  \n",
-       "1020011530  MULTIPOLYGON (((34.80278 -19.81667, 34.79279 -...  \n",
-       "1020018110  MULTIPOLYGON (((5.64444 -1.47083, 5.62972 -1.4...  \n",
-       "1020021940  MULTIPOLYGON (((0.97778 5.98750, 0.97022 5.988...  \n",
-       "1020027430  MULTIPOLYGON (((23.28611 32.22083, 23.28133 32...  "
+       "                                            geometry  \n",
+       "1  MULTIPOLYGON (((34.80278 -19.81667, 34.79279 -...  "
       ]
      },
-     "execution_count": 19,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "hybas_all_lev02_gdf.head()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "hybas_all_lev02_gdf.to_parquet(\n",
-    "    hybas_dir / 'hybas_all_lev02_gdf.parquet',\n",
-    "    compression='brotli',\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "NEXT_DOWN                                                    0\n",
-       "NEXT_SINK                                           1020011530\n",
-       "MAIN_BAS                                            1020011530\n",
-       "DIST_SINK                                                  0.0\n",
-       "DIST_MAIN                                                  0.0\n",
-       "SUB_AREA                                             4660080.9\n",
-       "UP_AREA                                              4660080.9\n",
-       "PFAF_ID                                                     12\n",
-       "ENDO                                                         0\n",
-       "COAST                                                        1\n",
-       "ORDER                                                        0\n",
-       "SORT                                                         2\n",
-       "geometry     MULTIPOLYGON (((34.8027777777778 -19.816666666...\n",
-       "Name: 1020011530, dtype: object"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "hybas_all_lev02_gdf.loc[1020011530]"
+    "hybas_all_lev02_gdf.loc[hybas_all_lev02_gdf.HYBAS_ID==1020011530]"
    ]
   },
   {
@@ -3333,7 +3422,9 @@
     "National Geospatial-Intelligence Agency (NGA)\n",
     "https://earth-info.nga.mil/\n",
     "\n",
-    "Attribute descriptions at [GEOGLOWS Data Guide - GIS Streams and Catchments](https://data.geoglows.org/dataset-descriptions/gis-streams-and-catchments), under [Stream Attributes](https://data.geoglows.org/dataset-descriptions/gis-streams-and-catchments#h.nxed06lf5wx6) \n",
+    "Docs: \n",
+    "- [TDX-Hydro Technical Document](https://earth-info.nga.mil/php/download.php?file=tdx-hydro-technical-doc) describes how the data were developed.\n",
+    "- Attribute descriptions at [GEOGLOWS Data Guide - GIS Streams and Catchments](https://data.geoglows.org/dataset-descriptions/gis-streams-and-catchments), under [Stream Attributes](https://data.geoglows.org/dataset-descriptions/gis-streams-and-catchments#h.nxed06lf5wx6) \n",
     "\n",
     "Download: **Africa**: 1020011530 `Drainage Basins`\n",
     "- https://earth-info.nga.mil/php/download.php?file=1020011530-basins-gpkg\n",
@@ -3344,26 +3435,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "['/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/TDX_streamnet_1020011530_01.gpkg',\n",
+       " '/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/TDX_streamnet_7020038340_01.parquet',\n",
        " '/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/TDX_streamreach_basins_7020038340_01.gpkg',\n",
        " '/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/.DS_Store',\n",
+       " '/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/TDX_streamnet_7020038340_01.gpkg-shm',\n",
+       " '/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/TDX_streamnet_7020038340_01.gpkg-wal',\n",
+       " '/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/TDX_streamreach_basins_7020038340_01.parquet',\n",
        " '/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/test.json',\n",
-       " '/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/download.php?file=hydrobasins_level2',\n",
        " '/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/test.zip',\n",
        " '/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/TDX_streamreach_basins_1020011530_01.gpkg',\n",
        " '/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/hydrobasins_level2.geojson',\n",
        " '/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/TDX_streamreach_basins_1020040190_01.gpkg',\n",
        " '/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/TDX_streamnet_7020038340_01.gpkg',\n",
-       " '/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/TDX_streamnet_7020038340_01.xedit.gpkg']"
+       " '/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/TDX_streamnet_7020038340_01_mnsi.parquet',\n",
+       " '/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/TDX_streamreach_basins_7020038340_01.gpkg-wal',\n",
+       " '/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/TDX_streamreach_basins_7020038340_01.gpkg-shm']"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3375,12 +3471,250 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
+    "tdx_hydroregions_fp = tdx_dir / 'hydrobasins_level2.geojson'\n",
     "tdx_basins_7020038340_fp = tdx_dir / 'TDX_streamreach_basins_7020038340_01.gpkg'\n",
     "tdx_stream_7020038340_fp = tdx_dir / 'TDX_streamnet_7020038340_01.gpkg'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Read TDXHydroRegion Info\n",
+    "\n",
+    "NGA’s TDX-Hydro v1 files are organized by:\n",
+    "- TDXHydroRegion = HYBAS_ID Level 2 codes \n",
+    "- Download: https://earth-info.nga.mil/php/download.php?file=hydrobasins_level2\n",
+    "- 62 globally\n",
+    "- Crosswalk from TDXHydroRegion to PFAF_ID values are provided in HydroBASINS Level 2 files (see above), such as https://data.hydrosheds.org/file/HydroBASINS/standard/hybas_af_lev02_v1c.zip "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'geopandas.geodataframe.GeoDataFrame'>\n",
+      "RangeIndex: 62 entries, 0 to 61\n",
+      "Data columns (total 3 columns):\n",
+      " #   Column    Non-Null Count  Dtype   \n",
+      "---  ------    --------------  -----   \n",
+      " 0   HYBAS_ID  62 non-null     int64   \n",
+      " 1   SUB_AREA  62 non-null     float64 \n",
+      " 2   geometry  62 non-null     geometry\n",
+      "dtypes: float64(1), geometry(1), int64(1)\n",
+      "memory usage: 1.6 KB\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>HYBAS_ID</th>\n",
+       "      <th>SUB_AREA</th>\n",
+       "      <th>geometry</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1020000010</td>\n",
+       "      <td>3258330.6</td>\n",
+       "      <td>MULTIPOLYGON (((38.1995 18.24379, 38.19861 18....</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1020011530</td>\n",
+       "      <td>4660080.9</td>\n",
+       "      <td>MULTIPOLYGON (((19.42136 -34.68525, 19.4203 -3...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1020018110</td>\n",
+       "      <td>4900405.1</td>\n",
+       "      <td>MULTIPOLYGON (((9.15742 -2.07022, 9.16221 -2.0...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1020021940</td>\n",
+       "      <td>4046600.5</td>\n",
+       "      <td>MULTIPOLYGON (((-16.1354 11.25485, -16.12926 1...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>1020027430</td>\n",
+       "      <td>6923559.6</td>\n",
+       "      <td>MULTIPOLYGON (((-16.48427 19.64912, -16.48272 ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>57</th>\n",
+       "      <td>3020003790</td>\n",
+       "      <td>2620366.5</td>\n",
+       "      <td>MULTIPOLYGON (((76.9259 72.15787, 76.925 72.16...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>58</th>\n",
+       "      <td>3020005240</td>\n",
+       "      <td>1173702.8</td>\n",
+       "      <td>MULTIPOLYGON (((84.71574 73.8423, 84.69252 73....</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>59</th>\n",
+       "      <td>3020008670</td>\n",
+       "      <td>2487156.5</td>\n",
+       "      <td>MULTIPOLYGON (((125.90113 73.46736, 125.98238 ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>60</th>\n",
+       "      <td>3020009320</td>\n",
+       "      <td>2722031.4</td>\n",
+       "      <td>MULTIPOLYGON (((138.39167 56.69923, 138.39028 ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>61</th>\n",
+       "      <td>3020024310</td>\n",
+       "      <td>302583.2</td>\n",
+       "      <td>MULTIPOLYGON (((97.95833 46.95417, 97.95869 46...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>62 rows × 3 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      HYBAS_ID   SUB_AREA                                           geometry\n",
+       "0   1020000010  3258330.6  MULTIPOLYGON (((38.1995 18.24379, 38.19861 18....\n",
+       "1   1020011530  4660080.9  MULTIPOLYGON (((19.42136 -34.68525, 19.4203 -3...\n",
+       "2   1020018110  4900405.1  MULTIPOLYGON (((9.15742 -2.07022, 9.16221 -2.0...\n",
+       "3   1020021940  4046600.5  MULTIPOLYGON (((-16.1354 11.25485, -16.12926 1...\n",
+       "4   1020027430  6923559.6  MULTIPOLYGON (((-16.48427 19.64912, -16.48272 ...\n",
+       "..         ...        ...                                                ...\n",
+       "57  3020003790  2620366.5  MULTIPOLYGON (((76.9259 72.15787, 76.925 72.16...\n",
+       "58  3020005240  1173702.8  MULTIPOLYGON (((84.71574 73.8423, 84.69252 73....\n",
+       "59  3020008670  2487156.5  MULTIPOLYGON (((125.90113 73.46736, 125.98238 ...\n",
+       "60  3020009320  2722031.4  MULTIPOLYGON (((138.39167 56.69923, 138.39028 ...\n",
+       "61  3020024310   302583.2  MULTIPOLYGON (((97.95833 46.95417, 97.95869 46...\n",
+       "\n",
+       "[62 rows x 3 columns]"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tdx_hydroregions_gdf = gpd.read_file(tdx_hydroregions_fp)\n",
+    "tdx_hydroregions_gdf.info()\n",
+    "tdx_hydroregions_gdf\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Geographic 2D CRS: EPSG:4326>\n",
+       "Name: WGS 84\n",
+       "Axis Info [ellipsoidal]:\n",
+       "- Lat[north]: Geodetic latitude (degree)\n",
+       "- Lon[east]: Geodetic longitude (degree)\n",
+       "Area of Use:\n",
+       "- name: World.\n",
+       "- bounds: (-180.0, -90.0, 180.0, 90.0)\n",
+       "Datum: World Geodetic System 1984 ensemble\n",
+       "- Ellipsoid: WGS 84\n",
+       "- Prime Meridian: Greenwich"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tdx_hydroregions_gdf.crs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Exploration of this polygon in QGIS shows that boundariesa are identical to HydroBASINS Level 2 Boundaries."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tdx_hydroregions_parquet = tdx_hydroregions_fp.with_suffix('.parquet')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Save as Geoparquet\n",
+    "tdx_hydroregions_gdf.to_parquet(tdx_hydroregions_parquet, compression='zstd')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "25.068297"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Get file size, in MB\n",
+    "tdx_hydroregions_parquet.stat().st_size / 1_000_000"
    ]
   },
   {
@@ -4219,6 +4553,13 @@
    "source": [
     "tdx_stream_7020038340_gdf"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",

--- a/sandbox/geoarrow_parquet.ipynb
+++ b/sandbox/geoarrow_parquet.ipynb
@@ -82,6 +82,7 @@
        " '/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/TDX_streamnet_7020038340_01.parquet',\n",
        " '/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/TDX_streamreach_basins_7020038340_01.gpkg',\n",
        " '/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/.DS_Store',\n",
+       " '/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/TDX_streamreach_basins_7020038340_01.parquet',\n",
        " '/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/test.json',\n",
        " '/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/download.php?file=hydrobasins_level2',\n",
        " '/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/test.zip',\n",
@@ -363,7 +364,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "3.52 ms ± 104 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+      "3.84 ms ± 285 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
@@ -381,7 +382,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "3.88 ms ± 73.2 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+      "3.83 ms ± 114 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
@@ -406,7 +407,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "522 ms ± 10.5 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "566 ms ± 42.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -433,7 +434,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "434 ms ± 5.91 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "441 ms ± 21 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -530,7 +531,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2.02 s ± 18.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "2.05 s ± 56.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -620,7 +621,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1.73 s ± 11.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "1.99 s ± 129 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -688,7 +689,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2.9 s ± 78.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "2.99 s ± 93 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -752,7 +753,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "516 ms ± 8.91 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "545 ms ± 7.16 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -845,8 +846,8 @@
       " 17  geometry    140097 non-null  geometry\n",
       "dtypes: float64(9), geometry(1), int32(7), int64(1)\n",
       "memory usage: 15.5 MB\n",
-      "CPU times: user 14.3 s, sys: 956 ms, total: 15.3 s\n",
-      "Wall time: 14.7 s\n"
+      "CPU times: user 14.6 s, sys: 1.09 s, total: 15.7 s\n",
+      "Wall time: 15.2 s\n"
      ]
     }
    ],
@@ -893,7 +894,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "548 ms ± 46.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "573 ms ± 38.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -1006,7 +1007,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1.86 ms ± 57.4 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)\n"
+      "2.03 ms ± 149 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
@@ -1309,7 +1310,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1.09 s ± 17.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "1.18 s ± 36.5 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -1671,7 +1672,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "138 ms ± 2.29 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "151 ms ± 12.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -1709,7 +1710,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "11.2 ms ± 1.31 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "10.6 ms ± 519 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
@@ -1743,7 +1744,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "147 ms ± 9.35 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "144 ms ± 5.26 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -1781,7 +1782,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "9.53 ms ± 80.9 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+      "9.6 ms ± 251 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
@@ -1823,7 +1824,7 @@
     {
      "data": {
       "text/plain": [
-       "<geopandas.array.GeometryDtype at 0x16a813050>"
+       "<geopandas.array.GeometryDtype at 0x16d4fbad0>"
       ]
      },
      "execution_count": 57,
@@ -1922,7 +1923,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "4.2 s ± 117 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "4.37 s ± 61.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -1974,7 +1975,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2.49 s ± 29.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "2.56 s ± 74.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -1992,7 +1993,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 92,
+   "execution_count": 64,
    "metadata": {},
    "outputs": [
     {
@@ -2011,14 +2012,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 65,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10.7 ms ± 152 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+      "11.1 ms ± 155 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
@@ -2037,7 +2038,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 66,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2047,14 +2048,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 67,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10.1 s ± 269 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "10.6 s ± 366 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -2065,7 +2066,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 68,
    "metadata": {},
    "outputs": [
     {
@@ -2074,7 +2075,7 @@
        "703127552"
       ]
      },
-     "execution_count": 70,
+     "execution_count": 68,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2127,7 +2128,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": 69,
    "metadata": {},
    "outputs": [
     {
@@ -2167,7 +2168,7 @@
        "bytes"
       ]
      },
-     "execution_count": 71,
+     "execution_count": 69,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2179,7 +2180,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": 70,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2188,14 +2189,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": 71,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2.74 s ± 45.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "2.89 s ± 60.5 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -2206,7 +2207,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": 72,
    "metadata": {},
    "outputs": [
     {
@@ -2215,7 +2216,7 @@
        "186784470"
       ]
      },
-     "execution_count": 74,
+     "execution_count": 72,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2227,14 +2228,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": 73,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1.59 s ± 31.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "1.6 s ± 46 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -2246,14 +2247,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": 74,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10 ms ± 35.1 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+      "10.4 ms ± 103 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
@@ -2272,7 +2273,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": 75,
    "metadata": {},
    "outputs": [
     {
@@ -2282,7 +2283,7 @@
        "  \"$schema\": \"https://p...>)"
       ]
      },
-     "execution_count": 77,
+     "execution_count": 75,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2293,7 +2294,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": 76,
    "metadata": {},
    "outputs": [
     {
@@ -2302,7 +2303,7 @@
        "geoarrow.pandas.lib.GeoArrowExtensionScalar"
       ]
      },
-     "execution_count": 78,
+     "execution_count": 76,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2313,7 +2314,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 77,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2322,14 +2323,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": 78,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1.98 s ± 36 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "2.06 s ± 46.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -2341,7 +2342,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": 79,
    "metadata": {},
    "outputs": [
     {
@@ -2350,7 +2351,7 @@
        "186793666"
       ]
      },
-     "execution_count": 81,
+     "execution_count": 79,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2362,14 +2363,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": 80,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1.43 s ± 14.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "1.51 s ± 34.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -2380,7 +2381,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": 81,
    "metadata": {},
    "outputs": [
     {
@@ -2419,7 +2420,7 @@
        "..."
       ]
      },
-     "execution_count": 83,
+     "execution_count": 81,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2437,7 +2438,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": 82,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2457,14 +2458,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": 83,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1.97 s ± 25.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "2.08 s ± 55 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -2476,7 +2477,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": 84,
    "metadata": {},
    "outputs": [
     {
@@ -2485,7 +2486,7 @@
        "186782750"
       ]
      },
-     "execution_count": 86,
+     "execution_count": 84,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2504,14 +2505,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
+   "execution_count": 85,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1.43 s ± 17.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "1.49 s ± 64.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -2523,7 +2524,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": 86,
    "metadata": {},
    "outputs": [
     {
@@ -2562,7 +2563,7 @@
        "..."
       ]
      },
-     "execution_count": 88,
+     "execution_count": 86,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2580,14 +2581,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 89,
+   "execution_count": 87,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1.32 s ± 16.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "1.41 s ± 58.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -2599,7 +2600,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": 88,
    "metadata": {},
    "outputs": [
     {
@@ -2638,7 +2639,7 @@
        "..."
       ]
      },
-     "execution_count": 90,
+     "execution_count": 88,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2657,7 +2658,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 116,
+   "execution_count": 89,
    "metadata": {},
    "outputs": [
     {
@@ -2699,7 +2700,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 117,
+   "execution_count": 90,
    "metadata": {},
    "outputs": [
     {
@@ -2730,7 +2731,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 119,
+   "execution_count": 91,
    "metadata": {},
    "outputs": [
     {
@@ -2767,7 +2768,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 120,
+   "execution_count": 92,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2781,7 +2782,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 121,
+   "execution_count": 93,
    "metadata": {},
    "outputs": [
     {
@@ -2822,7 +2823,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 122,
+   "execution_count": 94,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2831,14 +2832,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 123,
+   "execution_count": 95,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "4.52 s ± 117 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "4.18 s ± 117 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -2855,7 +2856,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 124,
+   "execution_count": 96,
    "metadata": {},
    "outputs": [
     {
@@ -2864,7 +2865,7 @@
        "186191314"
       ]
      },
-     "execution_count": 124,
+     "execution_count": 96,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2878,14 +2879,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 125,
+   "execution_count": 97,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2.6 s ± 28 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "2.95 s ± 617 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -2901,7 +2902,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 126,
+   "execution_count": 98,
    "metadata": {},
    "outputs": [
     {

--- a/sandbox/modified_nested_set_index.ipynb
+++ b/sandbox/modified_nested_set_index.ipynb
@@ -31,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 64,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -41,9 +41,45 @@
     "\n",
     "import pyogrio\n",
     "import geopandas as gpd\n",
+    "import pandas as pd\n",
     "\n",
+    "import global_hydrography as gh\n",
     "from global_hydrography.delineation.mnsi import modified_nest_set_index\n",
     "from global_hydrography.preprocess import TDXPreprocessor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['__builtins__',\n",
+       " '__cached__',\n",
+       " '__doc__',\n",
+       " '__file__',\n",
+       " '__loader__',\n",
+       " '__name__',\n",
+       " '__package__',\n",
+       " '__path__',\n",
+       " '__spec__',\n",
+       " 'delineation',\n",
+       " 'io',\n",
+       " 'mnsi',\n",
+       " 'preprocess',\n",
+       " 'process']"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Explore the namespace for global-hydrography modules, functions, etc.\n",
+    "dir(gh)"
    ]
   },
   {
@@ -57,7 +93,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -70,7 +106,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -83,7 +119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -91,11 +127,13 @@
       "text/plain": [
        "[PosixPath('/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/TDX_streamnet_1020011530_01.gpkg'),\n",
        " PosixPath('/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/TDX_streamnet_7020038340_01.parquet'),\n",
+       " PosixPath('/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/TDX_streamnet_7020038340_01.gpkg-shm'),\n",
+       " PosixPath('/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/TDX_streamnet_7020038340_01.gpkg-wal'),\n",
        " PosixPath('/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/TDX_streamnet_7020038340_01.gpkg'),\n",
        " PosixPath('/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/TDX_streamnet_7020038340_01_mnsi.parquet')]"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -120,7 +158,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -129,19 +167,19 @@
        "'TDX_streamnet_7020038340_01.gpkg'"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "file = files_to_process[2]\n",
+    "file = files_to_process[4]\n",
     "file.name"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -150,7 +188,7 @@
        "'.gpkg'"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -161,7 +199,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -170,7 +208,7 @@
        "7020038340"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -183,7 +221,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -217,7 +255,7 @@
        " 'dataset_metadata': None}"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -229,7 +267,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -238,7 +276,7 @@
        "'TDX_streamnet_7020038340_01'"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -249,7 +287,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -258,7 +296,7 @@
        "7020038340"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -269,7 +307,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -278,7 +316,7 @@
        "{'DBF_DATE_LAST_UPDATE': '2021-12-08'}"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -289,7 +327,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -504,7 +542,7 @@
        "4  LINESTRING (-69.687 46.37911, -69.687 46.379, ...  "
       ]
      },
-     "execution_count": 18,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -518,7 +556,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -537,7 +575,7 @@
        "- Prime Meridian: Greenwich"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -555,7 +593,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -565,7 +603,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -574,14 +612,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "5.02 ms ± 2.99 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "5.72 ms ± 3.73 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -593,7 +631,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -808,7 +846,7 @@
        "4  LINESTRING (-69.687 46.37911, -69.687 46.379, ...  "
       ]
      },
-     "execution_count": 23,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -829,7 +867,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -838,7 +876,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -877,7 +915,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -886,7 +924,7 @@
        "['WSNO', 'DSNODEID']"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -907,7 +945,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -917,7 +955,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -934,7 +972,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -943,7 +981,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -955,7 +993,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
@@ -999,7 +1037,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -1018,7 +1056,7 @@
        "- Prime Meridian: Greenwich"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1029,7 +1067,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
@@ -1038,7 +1076,7 @@
        "RangeIndex(start=0, stop=140097, step=1)"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1049,7 +1087,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 51,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set 'LINKNO' as index, to facilitate selection\n",
+    "# and interoperability with basins\n",
+    "mnsi_gdf.set_index('LINKNO', inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
    "metadata": {},
    "outputs": [
     {
@@ -1073,7 +1122,6 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>LINKNO</th>\n",
        "      <th>DSLINKNO</th>\n",
        "      <th>USLINKNO1</th>\n",
        "      <th>USLINKNO2</th>\n",
@@ -1081,11 +1129,19 @@
        "      <th>DISCOVER_TIME</th>\n",
        "      <th>FINISH_TIME</th>\n",
        "    </tr>\n",
+       "    <tr>\n",
+       "      <th>LINKNO</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>750000000</td>\n",
+       "      <th>750000000</th>\n",
        "      <td>750001777</td>\n",
        "      <td>-1</td>\n",
        "      <td>-1</td>\n",
@@ -1094,8 +1150,7 @@
        "      <td>53</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>750000001</td>\n",
+       "      <th>750000001</th>\n",
        "      <td>750002369</td>\n",
        "      <td>-1</td>\n",
        "      <td>-1</td>\n",
@@ -1104,8 +1159,7 @@
        "      <td>50</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>750000593</td>\n",
+       "      <th>750000593</th>\n",
        "      <td>750001777</td>\n",
        "      <td>-1</td>\n",
        "      <td>-1</td>\n",
@@ -1114,8 +1168,7 @@
        "      <td>52</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>750001777</td>\n",
+       "      <th>750001777</th>\n",
        "      <td>750002369</td>\n",
        "      <td>750000000</td>\n",
        "      <td>750000593</td>\n",
@@ -1124,8 +1177,7 @@
        "      <td>53</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>750000002</td>\n",
+       "      <th>750000002</th>\n",
        "      <td>750004146</td>\n",
        "      <td>-1</td>\n",
        "      <td>-1</td>\n",
@@ -1141,11 +1193,9 @@
        "      <td>...</td>\n",
        "      <td>...</td>\n",
        "      <td>...</td>\n",
-       "      <td>...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>140092</th>\n",
-       "      <td>750000587</td>\n",
+       "      <th>750000587</th>\n",
        "      <td>-1</td>\n",
        "      <td>-1</td>\n",
        "      <td>-1</td>\n",
@@ -1154,8 +1204,7 @@
        "      <td>2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>140093</th>\n",
-       "      <td>750001180</td>\n",
+       "      <th>750001180</th>\n",
        "      <td>-1</td>\n",
        "      <td>-1</td>\n",
        "      <td>-1</td>\n",
@@ -1164,8 +1213,7 @@
        "      <td>2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>140094</th>\n",
-       "      <td>750001772</td>\n",
+       "      <th>750001772</th>\n",
        "      <td>-1</td>\n",
        "      <td>-1</td>\n",
        "      <td>-1</td>\n",
@@ -1174,8 +1222,7 @@
        "      <td>2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>140095</th>\n",
-       "      <td>750000588</td>\n",
+       "      <th>750000588</th>\n",
        "      <td>-1</td>\n",
        "      <td>-1</td>\n",
        "      <td>-1</td>\n",
@@ -1184,8 +1231,7 @@
        "      <td>2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>140096</th>\n",
-       "      <td>750000589</td>\n",
+       "      <th>750000589</th>\n",
        "      <td>-1</td>\n",
        "      <td>-1</td>\n",
        "      <td>-1</td>\n",
@@ -1195,52 +1241,54 @@
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>140097 rows × 7 columns</p>\n",
+       "<p>140097 rows × 6 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
-       "           LINKNO   DSLINKNO  USLINKNO1  USLINKNO2    ROOT_ID  DISCOVER_TIME  \\\n",
-       "0       750000000  750001777         -1         -1  750021317             52   \n",
-       "1       750000001  750002369         -1         -1  750021317             49   \n",
-       "2       750000593  750001777         -1         -1  750021317             51   \n",
-       "3       750001777  750002369  750000000  750000593  750021317             50   \n",
-       "4       750000002  750004146         -1         -1  750021317             47   \n",
-       "...           ...        ...        ...        ...        ...            ...   \n",
-       "140092  750000587         -1         -1         -1  750000587              1   \n",
-       "140093  750001180         -1         -1         -1  750001180              1   \n",
-       "140094  750001772         -1         -1         -1  750001772              1   \n",
-       "140095  750000588         -1         -1         -1  750000588              1   \n",
-       "140096  750000589         -1         -1         -1  750000589              1   \n",
+       "            DSLINKNO  USLINKNO1  USLINKNO2    ROOT_ID  DISCOVER_TIME  \\\n",
+       "LINKNO                                                                 \n",
+       "750000000  750001777         -1         -1  750021317             52   \n",
+       "750000001  750002369         -1         -1  750021317             49   \n",
+       "750000593  750001777         -1         -1  750021317             51   \n",
+       "750001777  750002369  750000000  750000593  750021317             50   \n",
+       "750000002  750004146         -1         -1  750021317             47   \n",
+       "...              ...        ...        ...        ...            ...   \n",
+       "750000587         -1         -1         -1  750000587              1   \n",
+       "750001180         -1         -1         -1  750001180              1   \n",
+       "750001772         -1         -1         -1  750001772              1   \n",
+       "750000588         -1         -1         -1  750000588              1   \n",
+       "750000589         -1         -1         -1  750000589              1   \n",
        "\n",
-       "        FINISH_TIME  \n",
-       "0                53  \n",
-       "1                50  \n",
-       "2                52  \n",
-       "3                53  \n",
-       "4                48  \n",
-       "...             ...  \n",
-       "140092            2  \n",
-       "140093            2  \n",
-       "140094            2  \n",
-       "140095            2  \n",
-       "140096            2  \n",
+       "           FINISH_TIME  \n",
+       "LINKNO                  \n",
+       "750000000           53  \n",
+       "750000001           50  \n",
+       "750000593           52  \n",
+       "750001777           53  \n",
+       "750000002           48  \n",
+       "...                ...  \n",
+       "750000587            2  \n",
+       "750001180            2  \n",
+       "750001772            2  \n",
+       "750000588            2  \n",
+       "750000589            2  \n",
        "\n",
-       "[140097 rows x 7 columns]"
+       "[140097 rows x 6 columns]"
       ]
      },
-     "execution_count": 58,
+     "execution_count": 53,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "mnsi_gdf[['LINKNO', 'DSLINKNO', 'USLINKNO1', 'USLINKNO2', \n",
+    "mnsi_gdf[['DSLINKNO', 'USLINKNO1', 'USLINKNO2', \n",
     "          'ROOT_ID', 'DISCOVER_TIME', 'FINISH_TIME' ]]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 54,
    "metadata": {},
    "outputs": [
     {
@@ -1261,7 +1309,7 @@
        "Name: count, Length: 1635, dtype: int64"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 54,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1279,34 +1327,613 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 58,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "PosixPath('/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/TDX_streamnet_7020038340_01_mnsi.parquet')"
+       "PosixPath('/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/TDX_streamnet_7020038340_01_mnsi_test.parquet')"
       ]
      },
-     "execution_count": 51,
+     "execution_count": 58,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "tdx_parquet_path = tdx_dir / f\"{info['layer_name']}_mnsi.parquet\"\n",
+    "tdx_parquet_path = tdx_dir / f\"{info['layer_name']}_mnsi_test.parquet\"\n",
     "tdx_parquet_path\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 56,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'DBF_DATE_LAST_UPDATE': '2021-12-08'}"
+      ]
+     },
+     "execution_count": 56,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Test to see if adding metadata to gdf gets saved to parquet\n",
+    "mnsi_gdf.source_info = info['layer_metadata']\n",
+    "mnsi_gdf.source_info"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
    "metadata": {},
    "outputs": [],
    "source": [
     "#write back to a file\n",
     "mnsi_gdf.to_parquet(tdx_parquet_path, compression='zstd')"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'layer_name': 'TDX_streamnet_7020038340_01_mnsi',\n",
+       " 'crs': 'EPSG:4326',\n",
+       " 'encoding': 'UTF-8',\n",
+       " 'fields': array(['LINKNO', 'DSLINKNO', 'USLINKNO1', 'USLINKNO2', 'ROOT_ID',\n",
+       "        'DISCOVER_TIME', 'FINISH_TIME', 'strmOrder', 'Length', 'Magnitude',\n",
+       "        'DSContArea', 'strmDrop', 'Slope', 'StraightL', 'USContArea',\n",
+       "        'DOUTEND', 'DOUTSTART', 'DOUTMID'], dtype=object),\n",
+       " 'dtypes': array(['int32', 'int32', 'int32', 'int32', 'int32', 'int32', 'int32',\n",
+       "        'int32', 'float64', 'int32', 'float64', 'float64', 'float64',\n",
+       "        'float64', 'float64', 'float64', 'float64', 'float64'],\n",
+       "       dtype=object),\n",
+       " 'fid_column': '',\n",
+       " 'geometry_name': 'geometry',\n",
+       " 'geometry_type': 'LineString',\n",
+       " 'features': 140097,\n",
+       " 'total_bounds': (-89.82122222222222,\n",
+       "  24.558999999998896,\n",
+       "  -66.14133333333214,\n",
+       "  46.44544444444445),\n",
+       " 'driver': 'Parquet',\n",
+       " 'capabilities': {'random_read': False,\n",
+       "  'fast_set_next_by_index': True,\n",
+       "  'fast_spatial_filter': False,\n",
+       "  'fast_feature_count': True,\n",
+       "  'fast_total_bounds': True},\n",
+       " 'layer_metadata': None,\n",
+       " 'dataset_metadata': None}"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pyogrio.read_info(tdx_parquet_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Alternate: Create Basins with MNSI\n",
+    "\n",
+    "To only read the basin's file for delinating the upstream watershed boundary.\n",
+    "\n",
+    "Using new functions in source directory to streamline production."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<module 'global_hydrography.process' from '/Users/aaufdenkampe/Documents/Python/global-hydrography/src/global_hydrography/process.py'>"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Reload module after editing\n",
+    "reload(gh.process)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `select_tdx_files()` function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tdx_hydro_region = 7020038340"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'TDX_streamnet_7020038340_01.gpkg'"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Test new select_tdx_files()\n",
+    "streamnet_file, basins_file = gh.process.select_tdx_files(\n",
+    "    tdx_dir, tdxhydroregion,'.gpkg')\n",
+    "\n",
+    "streamnet_file.name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'TDX_streamreach_basins_7020038340_01.gpkg'"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "basins_file.name"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Process basins file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# open basins file as GeoDataFrame\n",
+    "basins_gdf = gpd.read_file(basins_file, engine='pyogrio', layer=0, use_arrow=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'geopandas.geodataframe.GeoDataFrame'>\n",
+      "Index: 140053 entries, 750000001 to 750327711\n",
+      "Data columns (total 1 columns):\n",
+      " #   Column    Non-Null Count   Dtype   \n",
+      "---  ------    --------------   -----   \n",
+      " 0   geometry  140053 non-null  geometry\n",
+      "dtypes: geometry(1)\n",
+      "memory usage: 2.1 MB\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Rename 'streamID' to 'LINKNO' to facilitate interoperability \n",
+    "# with streamnet files\n",
+    "basins_gdf.rename(columns={'streamID':'LINKNO'}, inplace=True)\n",
+    "\n",
+    "# apply preprocessing to make linkno globally unique\n",
+    "preprocessor.tdx_to_global_linkno(basins_gdf, tdx_hydro_region)\n",
+    "\n",
+    "# Set 'LINKNO' as index, to facilitate selection\n",
+    "basins_gdf.set_index('LINKNO', inplace=True)\n",
+    "\n",
+    "basins_gdf.info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Move MNSI fields from streamnet to basins"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 77,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stream_mnsi_gdf = mnsi_gdf.copy(deep=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 78,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'geopandas.geodataframe.GeoDataFrame'>\n",
+      "Index: 140097 entries, 750000000 to 750000589\n",
+      "Data columns (total 3 columns):\n",
+      " #   Column      Non-Null Count   Dtype   \n",
+      "---  ------      --------------   -----   \n",
+      " 0   geometry    140053 non-null  geometry\n",
+      " 1   DSContArea  140097 non-null  float64 \n",
+      " 2   USContArea  140097 non-null  float64 \n",
+      "dtypes: float64(2), geometry(1)\n",
+      "memory usage: 4.3 MB\n"
+     ]
+    }
+   ],
+   "source": [
+    "columns_to_merge = ['DSContArea', 'USContArea']\n",
+    "\n",
+    "# Merge confirms that their LINKNO values match\n",
+    "# Although there are not as many basins as there are stream reaches!\n",
+    "basins_test_gdf = pd.merge(\n",
+    "    basins_test_gdf, \n",
+    "    stream_mnsi_gdf[columns_to_merge], \n",
+    "    how='right', \n",
+    "    on='LINKNO',\n",
+    ")\n",
+    "basins_test_gdf.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 81,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'geopandas.geodataframe.GeoDataFrame'>\n",
+      "Index: 44 entries, 750000000 to 750020103\n",
+      "Data columns (total 18 columns):\n",
+      " #   Column         Non-Null Count  Dtype   \n",
+      "---  ------         --------------  -----   \n",
+      " 0   DSLINKNO       44 non-null     int32   \n",
+      " 1   USLINKNO1      44 non-null     int32   \n",
+      " 2   USLINKNO2      44 non-null     int32   \n",
+      " 3   ROOT_ID        44 non-null     int32   \n",
+      " 4   DISCOVER_TIME  44 non-null     int32   \n",
+      " 5   FINISH_TIME    44 non-null     int32   \n",
+      " 6   strmOrder      44 non-null     int32   \n",
+      " 7   Length         44 non-null     float64 \n",
+      " 8   Magnitude      44 non-null     int32   \n",
+      " 9   DSContArea     44 non-null     float64 \n",
+      " 10  strmDrop       44 non-null     float64 \n",
+      " 11  Slope          44 non-null     float64 \n",
+      " 12  StraightL      44 non-null     float64 \n",
+      " 13  USContArea     44 non-null     float64 \n",
+      " 14  DOUTEND        44 non-null     float64 \n",
+      " 15  DOUTSTART      44 non-null     float64 \n",
+      " 16  DOUTMID        44 non-null     float64 \n",
+      " 17  geometry       44 non-null     geometry\n",
+      "dtypes: float64(9), geometry(1), int32(8)\n",
+      "memory usage: 5.0 KB\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>DSLINKNO</th>\n",
+       "      <th>USLINKNO1</th>\n",
+       "      <th>USLINKNO2</th>\n",
+       "      <th>ROOT_ID</th>\n",
+       "      <th>DISCOVER_TIME</th>\n",
+       "      <th>FINISH_TIME</th>\n",
+       "      <th>strmOrder</th>\n",
+       "      <th>Length</th>\n",
+       "      <th>Magnitude</th>\n",
+       "      <th>DSContArea</th>\n",
+       "      <th>strmDrop</th>\n",
+       "      <th>Slope</th>\n",
+       "      <th>StraightL</th>\n",
+       "      <th>USContArea</th>\n",
+       "      <th>DOUTEND</th>\n",
+       "      <th>DOUTSTART</th>\n",
+       "      <th>DOUTMID</th>\n",
+       "      <th>geometry</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>LINKNO</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>750000000</th>\n",
+       "      <td>750001777</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>750021317</td>\n",
+       "      <td>52</td>\n",
+       "      <td>53</td>\n",
+       "      <td>1</td>\n",
+       "      <td>3847.9</td>\n",
+       "      <td>1</td>\n",
+       "      <td>9.567845e+06</td>\n",
+       "      <td>42.07</td>\n",
+       "      <td>0.010933</td>\n",
+       "      <td>3233.7</td>\n",
+       "      <td>5.254868e+06</td>\n",
+       "      <td>45853.6</td>\n",
+       "      <td>49701.4</td>\n",
+       "      <td>47777.5</td>\n",
+       "      <td>LINESTRING (-69.67822 46.41356, -69.67822 46.4...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>750100709</th>\n",
+       "      <td>750101301</td>\n",
+       "      <td>750090644</td>\n",
+       "      <td>750068149</td>\n",
+       "      <td>750100710</td>\n",
+       "      <td>5</td>\n",
+       "      <td>16</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>6</td>\n",
+       "      <td>9.573266e+07</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>9.573266e+07</td>\n",
+       "      <td>7889.2</td>\n",
+       "      <td>7889.2</td>\n",
+       "      <td>7889.2</td>\n",
+       "      <td>LINESTRING (-69.74322 43.89322, -69.74322 43.8...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>750155209</th>\n",
+       "      <td>750155801</td>\n",
+       "      <td>750154617</td>\n",
+       "      <td>750113177</td>\n",
+       "      <td>750170058</td>\n",
+       "      <td>1767</td>\n",
+       "      <td>4980</td>\n",
+       "      <td>7</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1607</td>\n",
+       "      <td>2.410359e+10</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>2.410359e+10</td>\n",
+       "      <td>234019.3</td>\n",
+       "      <td>234019.3</td>\n",
+       "      <td>234019.3</td>\n",
+       "      <td>LINESTRING (-73.75744 42.54056, -73.75744 42.5...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>750127463</th>\n",
+       "      <td>750128055</td>\n",
+       "      <td>750141672</td>\n",
+       "      <td>750010841</td>\n",
+       "      <td>750129283</td>\n",
+       "      <td>3471</td>\n",
+       "      <td>4886</td>\n",
+       "      <td>6</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>708</td>\n",
+       "      <td>1.099047e+10</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.099047e+10</td>\n",
+       "      <td>423795.8</td>\n",
+       "      <td>423795.8</td>\n",
+       "      <td>423795.8</td>\n",
+       "      <td>LINESTRING (-78.23989 39.65089, -78.23989 39.6...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>750099079</th>\n",
+       "      <td>750099671</td>\n",
+       "      <td>750055269</td>\n",
+       "      <td>750055861</td>\n",
+       "      <td>750102638</td>\n",
+       "      <td>89</td>\n",
+       "      <td>96</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>4</td>\n",
+       "      <td>8.714499e+07</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>8.714499e+07</td>\n",
+       "      <td>68889.3</td>\n",
+       "      <td>68889.3</td>\n",
+       "      <td>68889.3</td>\n",
+       "      <td>LINESTRING (-76.08133 38.47233, -76.08133 38.4...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "            DSLINKNO  USLINKNO1  USLINKNO2    ROOT_ID  DISCOVER_TIME  \\\n",
+       "LINKNO                                                                 \n",
+       "750000000  750001777         -1         -1  750021317             52   \n",
+       "750100709  750101301  750090644  750068149  750100710              5   \n",
+       "750155209  750155801  750154617  750113177  750170058           1767   \n",
+       "750127463  750128055  750141672  750010841  750129283           3471   \n",
+       "750099079  750099671  750055269  750055861  750102638             89   \n",
+       "\n",
+       "           FINISH_TIME  strmOrder  Length  Magnitude    DSContArea  strmDrop  \\\n",
+       "LINKNO                                                                         \n",
+       "750000000           53          1  3847.9          1  9.567845e+06     42.07   \n",
+       "750100709           16          3     0.0          6  9.573266e+07      0.00   \n",
+       "750155209         4980          7     0.0       1607  2.410359e+10      0.00   \n",
+       "750127463         4886          6     0.0        708  1.099047e+10      0.00   \n",
+       "750099079           96          2     0.0          4  8.714499e+07      0.00   \n",
+       "\n",
+       "              Slope  StraightL    USContArea   DOUTEND  DOUTSTART   DOUTMID  \\\n",
+       "LINKNO                                                                        \n",
+       "750000000  0.010933     3233.7  5.254868e+06   45853.6    49701.4   47777.5   \n",
+       "750100709  0.000000        0.0  9.573266e+07    7889.2     7889.2    7889.2   \n",
+       "750155209  0.000000        0.0  2.410359e+10  234019.3   234019.3  234019.3   \n",
+       "750127463  0.000000        0.0  1.099047e+10  423795.8   423795.8  423795.8   \n",
+       "750099079  0.000000        0.0  8.714499e+07   68889.3    68889.3   68889.3   \n",
+       "\n",
+       "                                                    geometry  \n",
+       "LINKNO                                                        \n",
+       "750000000  LINESTRING (-69.67822 46.41356, -69.67822 46.4...  \n",
+       "750100709  LINESTRING (-69.74322 43.89322, -69.74322 43.8...  \n",
+       "750155209  LINESTRING (-73.75744 42.54056, -73.75744 42.5...  \n",
+       "750127463  LINESTRING (-78.23989 39.65089, -78.23989 39.6...  \n",
+       "750099079  LINESTRING (-76.08133 38.47233, -76.08133 38.4...  "
+      ]
+     },
+     "execution_count": 81,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Explore stream links with no basin geometry.\n",
+    "streams_no_basins_gdf = stream_mnsi_gdf[basins_test_gdf.geometry==None]\n",
+    "streams_no_basins_gdf.info()\n",
+    "streams_no_basins_gdf.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 84,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Length\n",
+       "0.0       43\n",
+       "3847.9     1\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 84,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "streams_no_basins_gdf.Length.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**NOTE: All but one have zero stream length. The one with a lenghth is a headwater stream at the edge of the TDXHydroRegion."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 83,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Write to GeoPackage to explore in QGIS\n",
+    "pyogrio.write_dataframe(streams_no_basins_gdf, tdx_dir / 'streams_no_basins.gpkg')\n",
+    "# looks like random mistakes\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DISCOVER = \"DISCOVER_TIME\"\n",
+    "FINISH = \"FINISH_TIME\"\n",
+    "ROOT = \"ROOT_ID\"\n",
+    "# at column locations right after other LINK info\n",
+    "for f in (FINISH, DISCOVER, ROOT):\n",
+    "    basins_gdf.insert(0, f, None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/sandbox/modified_nested_set_index.ipynb
+++ b/sandbox/modified_nested_set_index.ipynb
@@ -31,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -619,7 +619,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "5.72 ms ± 3.73 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "The slowest run took 17.65 times longer than the fastest. This could mean that an intermediate result is being cached.\n",
+      "15.2 ms ± 20.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -1087,7 +1088,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1098,7 +1099,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
@@ -1276,7 +1277,7 @@
        "[140097 rows x 6 columns]"
       ]
      },
-     "execution_count": 53,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1288,7 +1289,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
@@ -1309,13 +1310,45 @@
        "Name: count, Length: 1635, dtype: int64"
       ]
      },
-     "execution_count": 54,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "mnsi_gdf.ROOT_ID.value_counts().sort_values()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DISCOVER_TIME\n",
+       "11091       1\n",
+       "11095       1\n",
+       "11119       1\n",
+       "11121       1\n",
+       "11099       1\n",
+       "         ... \n",
+       "5         526\n",
+       "4         526\n",
+       "2         734\n",
+       "3         734\n",
+       "1        1635\n",
+       "Name: count, Length: 14095, dtype: int64"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mnsi_gdf.DISCOVER_TIME.value_counts().sort_values()"
    ]
   },
   {
@@ -1327,7 +1360,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
@@ -1336,7 +1369,7 @@
        "PosixPath('/Users/aaufdenkampe/Documents/Python/global-hydrography/data_temp/nga/TDX_streamnet_7020038340_01_mnsi_test.parquet')"
       ]
      },
-     "execution_count": 58,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1348,16 +1381,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/aaufdenkampe/miniconda3/envs/hydrography/lib/python3.11/site-packages/geopandas/geodataframe.py:223: UserWarning: Pandas doesn't allow columns to be created via a new attribute name - see https://pandas.pydata.org/pandas-docs/stable/indexing.html#attribute-access\n",
+      "  super().__setattr__(attr, val)\n"
+     ]
+    },
     {
      "data": {
       "text/plain": [
        "{'DBF_DATE_LAST_UPDATE': '2021-12-08'}"
       ]
      },
-     "execution_count": 56,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1370,7 +1411,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1380,23 +1421,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'layer_name': 'TDX_streamnet_7020038340_01_mnsi',\n",
+       "{'layer_name': 'TDX_streamnet_7020038340_01_mnsi_test',\n",
        " 'crs': 'EPSG:4326',\n",
        " 'encoding': 'UTF-8',\n",
-       " 'fields': array(['LINKNO', 'DSLINKNO', 'USLINKNO1', 'USLINKNO2', 'ROOT_ID',\n",
-       "        'DISCOVER_TIME', 'FINISH_TIME', 'strmOrder', 'Length', 'Magnitude',\n",
-       "        'DSContArea', 'strmDrop', 'Slope', 'StraightL', 'USContArea',\n",
-       "        'DOUTEND', 'DOUTSTART', 'DOUTMID'], dtype=object),\n",
+       " 'fields': array(['DSLINKNO', 'USLINKNO1', 'USLINKNO2', 'ROOT_ID', 'DISCOVER_TIME',\n",
+       "        'FINISH_TIME', 'strmOrder', 'Length', 'Magnitude', 'DSContArea',\n",
+       "        'strmDrop', 'Slope', 'StraightL', 'USContArea', 'DOUTEND',\n",
+       "        'DOUTSTART', 'DOUTMID', 'LINKNO'], dtype=object),\n",
        " 'dtypes': array(['int32', 'int32', 'int32', 'int32', 'int32', 'int32', 'int32',\n",
-       "        'int32', 'float64', 'int32', 'float64', 'float64', 'float64',\n",
-       "        'float64', 'float64', 'float64', 'float64', 'float64'],\n",
-       "       dtype=object),\n",
+       "        'float64', 'int32', 'float64', 'float64', 'float64', 'float64',\n",
+       "        'float64', 'float64', 'float64', 'float64', 'int32'], dtype=object),\n",
        " 'fid_column': '',\n",
        " 'geometry_name': 'geometry',\n",
        " 'geometry_type': 'LineString',\n",
@@ -1415,7 +1455,7 @@
        " 'dataset_metadata': None}"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1437,7 +1477,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [
     {
@@ -1446,7 +1486,7 @@
        "<module 'global_hydrography.process' from '/Users/aaufdenkampe/Documents/Python/global-hydrography/src/global_hydrography/process.py'>"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1465,7 +1505,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1474,7 +1514,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [
     {
@@ -1483,7 +1523,7 @@
        "'TDX_streamnet_7020038340_01.gpkg'"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1491,14 +1531,14 @@
    "source": [
     "# Test new select_tdx_files()\n",
     "streamnet_file, basins_file = gh.process.select_tdx_files(\n",
-    "    tdx_dir, tdxhydroregion,'.gpkg')\n",
+    "    tdx_dir, tdx_hydro_region,'.gpkg')\n",
     "\n",
     "streamnet_file.name"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [
     {
@@ -1507,7 +1547,7 @@
        "'TDX_streamreach_basins_7020038340_01.gpkg'"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 44,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1525,7 +1565,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 62,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1535,7 +1575,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 63,
    "metadata": {},
    "outputs": [
     {
@@ -1576,7 +1616,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": 119,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1585,7 +1625,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": 120,
    "metadata": {},
    "outputs": [
     {
@@ -1611,7 +1651,7 @@
     "# Merge confirms that their LINKNO values match\n",
     "# Although there are not as many basins as there are stream reaches!\n",
     "basins_test_gdf = pd.merge(\n",
-    "    basins_test_gdf, \n",
+    "    basins_gdf, \n",
     "    stream_mnsi_gdf[columns_to_merge], \n",
     "    how='right', \n",
     "    on='LINKNO',\n",
@@ -1621,7 +1661,117 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": 121,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "32.5 ms ± 3.26 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "# Merges are very fast!\n",
+    "pd.merge(basins_gdf, stream_mnsi_gdf[columns_to_merge], how='right', on='LINKNO')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 122,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'geopandas.geodataframe.GeoDataFrame'>\n",
+      "Index: 140097 entries, 750000000 to 750000589\n",
+      "Data columns (total 4 columns):\n",
+      " #   Column      Non-Null Count   Dtype   \n",
+      "---  ------      --------------   -----   \n",
+      " 0   ROOT_ID     140097 non-null  int32   \n",
+      " 1   geometry    140053 non-null  geometry\n",
+      " 2   DSContArea  140097 non-null  float64 \n",
+      " 3   USContArea  140097 non-null  float64 \n",
+      "dtypes: float64(2), geometry(1), int32(1)\n",
+      "memory usage: 4.8 MB\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Pandas insert allows placement of column at a specified location.\n",
+    "ROOT = \"ROOT_ID\"\n",
+    "basins_test_gdf.insert(0, ROOT, stream_mnsi_gdf[ROOT])\n",
+    "basins_test_gdf.info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 123,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 1.27 ms, sys: 624 µs, total: 1.89 ms\n",
+      "Wall time: 1.01 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "# Insert is even faster!\n",
+    "DISCOVER = \"DISCOVER_TIME\"\n",
+    "basins_test_gdf.insert(0, DISCOVER, stream_mnsi_gdf[DISCOVER])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 124,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'geopandas.geodataframe.GeoDataFrame'>\n",
+      "Index: 140097 entries, 750000000 to 750000589\n",
+      "Data columns (total 5 columns):\n",
+      " #   Column         Non-Null Count   Dtype   \n",
+      "---  ------         --------------   -----   \n",
+      " 0   DISCOVER_TIME  140097 non-null  int32   \n",
+      " 1   ROOT_ID        140097 non-null  int32   \n",
+      " 2   geometry       140053 non-null  geometry\n",
+      " 3   DSContArea     140097 non-null  float64 \n",
+      " 4   USContArea     140097 non-null  float64 \n",
+      "dtypes: float64(2), geometry(1), int32(2)\n",
+      "memory usage: 5.3 MB\n"
+     ]
+    }
+   ],
+   "source": [
+    "basins_test_gdf.info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Streams with no Basins"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 125,
    "metadata": {},
    "outputs": [
     {
@@ -1861,21 +2011,21 @@
        "750099079  LINESTRING (-76.08133 38.47233, -76.08133 38.4...  "
       ]
      },
-     "execution_count": 81,
+     "execution_count": 125,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# Explore stream links with no basin geometry.\n",
-    "streams_no_basins_gdf = stream_mnsi_gdf[basins_test_gdf.geometry==None]\n",
-    "streams_no_basins_gdf.info()\n",
-    "streams_no_basins_gdf.head()"
+    "streams_no_basin_gdf = stream_mnsi_gdf[basins_test_gdf.geometry==None]\n",
+    "streams_no_basin_gdf.info()\n",
+    "streams_no_basin_gdf.head()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": 126,
    "metadata": {},
    "outputs": [
     {
@@ -1887,7 +2037,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 84,
+     "execution_count": 126,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1905,13 +2055,575 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": 127,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Write to GeoPackage to explore in QGIS\n",
-    "pyogrio.write_dataframe(streams_no_basins_gdf, tdx_dir / 'streams_no_basins.gpkg')\n",
+    "pyogrio.write_dataframe(streams_no_basin_gdf, tdx_dir / 'streams_no_basins.gpkg')\n",
     "# looks like random mistakes\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 128,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'geopandas.geodataframe.GeoDataFrame'>\n",
+      "Index: 140053 entries, 750000001 to 750000589\n",
+      "Data columns (total 5 columns):\n",
+      " #   Column         Non-Null Count   Dtype   \n",
+      "---  ------         --------------   -----   \n",
+      " 0   DISCOVER_TIME  140053 non-null  int32   \n",
+      " 1   ROOT_ID        140053 non-null  int32   \n",
+      " 2   geometry       140053 non-null  geometry\n",
+      " 3   DSContArea     140053 non-null  float64 \n",
+      " 4   USContArea     140053 non-null  float64 \n",
+      "dtypes: float64(2), geometry(1), int32(2)\n",
+      "memory usage: 5.3 MB\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Drop no-geometry rows from basins gdf\n",
+    "basins_test_gdf.drop(streams_no_basin_gdf.index.to_list(), inplace=True)\n",
+    "basins_test_gdf.info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Use `create_basins_mnsi()` function\n",
+    "That combines above"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 129,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<module 'global_hydrography.delineation.mnsi' from '/Users/aaufdenkampe/Documents/Python/global-hydrography/src/global_hydrography/delineation/mnsi.py'>"
+      ]
+     },
+     "execution_count": 129,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "reload(gh.process)\n",
+    "reload(gh.mnsi)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 130,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'geopandas.geodataframe.GeoDataFrame'>\n",
+      "Index: 140053 entries, 750000001 to 750000589\n",
+      "Data columns (total 4 columns):\n",
+      " #   Column         Non-Null Count   Dtype   \n",
+      "---  ------         --------------   -----   \n",
+      " 0   geometry       140053 non-null  geometry\n",
+      " 1   ROOT_ID        140053 non-null  int32   \n",
+      " 2   FINISH_TIME    140053 non-null  int32   \n",
+      " 3   DISCOVER_TIME  140053 non-null  int32   \n",
+      "dtypes: geometry(1), int32(3)\n",
+      "memory usage: 3.7 MB\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>geometry</th>\n",
+       "      <th>ROOT_ID</th>\n",
+       "      <th>FINISH_TIME</th>\n",
+       "      <th>DISCOVER_TIME</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>LINKNO</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>750000001</th>\n",
+       "      <td>POLYGON ((-69.71706 46.42639, -69.71572 46.426...</td>\n",
+       "      <td>750021317</td>\n",
+       "      <td>50</td>\n",
+       "      <td>49</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>750000593</th>\n",
+       "      <td>POLYGON ((-69.70117 46.4495, -69.70106 46.4495...</td>\n",
+       "      <td>750021317</td>\n",
+       "      <td>52</td>\n",
+       "      <td>51</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>750001777</th>\n",
+       "      <td>POLYGON ((-69.68828 46.41661, -69.68783 46.416...</td>\n",
+       "      <td>750021317</td>\n",
+       "      <td>53</td>\n",
+       "      <td>50</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>750000002</th>\n",
+       "      <td>POLYGON ((-69.71939 46.39428, -69.71928 46.394...</td>\n",
+       "      <td>750021317</td>\n",
+       "      <td>48</td>\n",
+       "      <td>47</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>750000592</th>\n",
+       "      <td>POLYGON ((-69.61317 46.46194, -69.61272 46.461...</td>\n",
+       "      <td>750021317</td>\n",
+       "      <td>41</td>\n",
+       "      <td>40</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                    geometry    ROOT_ID  \\\n",
+       "LINKNO                                                                    \n",
+       "750000001  POLYGON ((-69.71706 46.42639, -69.71572 46.426...  750021317   \n",
+       "750000593  POLYGON ((-69.70117 46.4495, -69.70106 46.4495...  750021317   \n",
+       "750001777  POLYGON ((-69.68828 46.41661, -69.68783 46.416...  750021317   \n",
+       "750000002  POLYGON ((-69.71939 46.39428, -69.71928 46.394...  750021317   \n",
+       "750000592  POLYGON ((-69.61317 46.46194, -69.61272 46.461...  750021317   \n",
+       "\n",
+       "           FINISH_TIME  DISCOVER_TIME  \n",
+       "LINKNO                                 \n",
+       "750000001           50             49  \n",
+       "750000593           52             51  \n",
+       "750001777           53             50  \n",
+       "750000002           48             47  \n",
+       "750000592           41             40  "
+      ]
+     },
+     "execution_count": 130,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "basins_mnsi_gdf, streams_no_basin_gdf2 = gh.process.create_basins_mnsi(\n",
+    "    basins_gdf,\n",
+    "    stream_mnsi_gdf,\n",
+    ")\n",
+    "basins_mnsi_gdf.info()\n",
+    "basins_mnsi_gdf.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 131,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'geopandas.geodataframe.GeoDataFrame'>\n",
+      "Index: 140097 entries, 750000000 to 750000589\n",
+      "Data columns (total 18 columns):\n",
+      " #   Column         Non-Null Count   Dtype   \n",
+      "---  ------         --------------   -----   \n",
+      " 0   DSLINKNO       140097 non-null  int32   \n",
+      " 1   USLINKNO1      140097 non-null  int32   \n",
+      " 2   USLINKNO2      140097 non-null  int32   \n",
+      " 3   ROOT_ID        140097 non-null  int32   \n",
+      " 4   DISCOVER_TIME  140097 non-null  int32   \n",
+      " 5   FINISH_TIME    140097 non-null  int32   \n",
+      " 6   strmOrder      140097 non-null  int32   \n",
+      " 7   Length         140097 non-null  float64 \n",
+      " 8   Magnitude      140097 non-null  int32   \n",
+      " 9   DSContArea     140097 non-null  float64 \n",
+      " 10  strmDrop       140097 non-null  float64 \n",
+      " 11  Slope          140097 non-null  float64 \n",
+      " 12  StraightL      140097 non-null  float64 \n",
+      " 13  USContArea     140097 non-null  float64 \n",
+      " 14  DOUTEND        140097 non-null  float64 \n",
+      " 15  DOUTSTART      140097 non-null  float64 \n",
+      " 16  DOUTMID        140097 non-null  float64 \n",
+      " 17  geometry       140097 non-null  geometry\n",
+      "dtypes: float64(9), geometry(1), int32(8)\n",
+      "memory usage: 18.5 MB\n"
+     ]
+    }
+   ],
+   "source": [
+    "stream_mnsi_gdf.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 132,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>DSLINKNO</th>\n",
+       "      <th>USLINKNO1</th>\n",
+       "      <th>USLINKNO2</th>\n",
+       "      <th>strmOrder</th>\n",
+       "      <th>Length</th>\n",
+       "      <th>Magnitude</th>\n",
+       "      <th>DSContArea</th>\n",
+       "      <th>strmDrop</th>\n",
+       "      <th>Slope</th>\n",
+       "      <th>StraightL</th>\n",
+       "      <th>USContArea</th>\n",
+       "      <th>DOUTEND</th>\n",
+       "      <th>DOUTSTART</th>\n",
+       "      <th>DOUTMID</th>\n",
+       "      <th>geometry</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>LINKNO</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>750000000</th>\n",
+       "      <td>750001777</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>3847.9</td>\n",
+       "      <td>1</td>\n",
+       "      <td>9567845.0</td>\n",
+       "      <td>42.07</td>\n",
+       "      <td>0.010933</td>\n",
+       "      <td>3233.7</td>\n",
+       "      <td>5254867.5</td>\n",
+       "      <td>45853.6</td>\n",
+       "      <td>49701.4</td>\n",
+       "      <td>47777.5</td>\n",
+       "      <td>LINESTRING (-69.67822 46.41356, -69.67822 46.4...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>750000001</th>\n",
+       "      <td>750002369</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2251.3</td>\n",
+       "      <td>1</td>\n",
+       "      <td>8768556.0</td>\n",
+       "      <td>34.66</td>\n",
+       "      <td>0.015397</td>\n",
+       "      <td>1749.2</td>\n",
+       "      <td>4320561.0</td>\n",
+       "      <td>44802.7</td>\n",
+       "      <td>47054.1</td>\n",
+       "      <td>45928.4</td>\n",
+       "      <td>LINESTRING (-69.68589 46.40778, -69.686 46.407...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>750000593</th>\n",
+       "      <td>750001777</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1469.3</td>\n",
+       "      <td>1</td>\n",
+       "      <td>8466694.0</td>\n",
+       "      <td>11.98</td>\n",
+       "      <td>0.008153</td>\n",
+       "      <td>1286.2</td>\n",
+       "      <td>4319318.0</td>\n",
+       "      <td>45853.6</td>\n",
+       "      <td>47322.9</td>\n",
+       "      <td>46588.3</td>\n",
+       "      <td>LINESTRING (-69.67822 46.41356, -69.67811 46.4...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>750001777</th>\n",
+       "      <td>750002369</td>\n",
+       "      <td>750000000</td>\n",
+       "      <td>750000593</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1050.9</td>\n",
+       "      <td>2</td>\n",
+       "      <td>19939082.0</td>\n",
+       "      <td>0.91</td>\n",
+       "      <td>0.000870</td>\n",
+       "      <td>871.8</td>\n",
+       "      <td>18034788.0</td>\n",
+       "      <td>44802.7</td>\n",
+       "      <td>45853.6</td>\n",
+       "      <td>45328.2</td>\n",
+       "      <td>LINESTRING (-69.68589 46.40778, -69.68589 46.4...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>750000002</th>\n",
+       "      <td>750004146</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>3551.0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>9120895.0</td>\n",
+       "      <td>67.48</td>\n",
+       "      <td>0.019002</td>\n",
+       "      <td>2593.6</td>\n",
+       "      <td>5267176.0</td>\n",
+       "      <td>41041.1</td>\n",
+       "      <td>44591.7</td>\n",
+       "      <td>42816.4</td>\n",
+       "      <td>LINESTRING (-69.687 46.37911, -69.687 46.379, ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>750000587</th>\n",
+       "      <td>-1</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2354.1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>10233235.0</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>1721.9</td>\n",
+       "      <td>7569312.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>2354.1</td>\n",
+       "      <td>1177.1</td>\n",
+       "      <td>LINESTRING (-81.59922 24.64033, -81.59911 24.6...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>750001180</th>\n",
+       "      <td>-1</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1326.7</td>\n",
+       "      <td>1</td>\n",
+       "      <td>9136435.0</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>1072.3</td>\n",
+       "      <td>4495984.5</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1326.7</td>\n",
+       "      <td>663.4</td>\n",
+       "      <td>LINESTRING (-81.63022 24.61767, -81.63011 24.6...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>750001772</th>\n",
+       "      <td>-1</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1000.1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>4879280.0</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>738.8</td>\n",
+       "      <td>4387448.5</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1000.1</td>\n",
+       "      <td>500.0</td>\n",
+       "      <td>LINESTRING (-81.60144 24.58478, -81.60156 24.5...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>750000588</th>\n",
+       "      <td>-1</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2044.7</td>\n",
+       "      <td>1</td>\n",
+       "      <td>5911555.0</td>\n",
+       "      <td>0.76</td>\n",
+       "      <td>0.000370</td>\n",
+       "      <td>1396.2</td>\n",
+       "      <td>4346421.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>2044.7</td>\n",
+       "      <td>1022.4</td>\n",
+       "      <td>LINESTRING (-81.64478 24.57489, -81.64489 24.5...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>750000589</th>\n",
+       "      <td>-1</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>868.5</td>\n",
+       "      <td>1</td>\n",
+       "      <td>5180645.5</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>775.9</td>\n",
+       "      <td>5107666.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>868.5</td>\n",
+       "      <td>434.3</td>\n",
+       "      <td>LINESTRING (-81.68 24.559, -81.68011 24.55911,...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>140097 rows × 15 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "            DSLINKNO  USLINKNO1  USLINKNO2  strmOrder  Length  Magnitude  \\\n",
+       "LINKNO                                                                     \n",
+       "750000000  750001777         -1         -1          1  3847.9          1   \n",
+       "750000001  750002369         -1         -1          1  2251.3          1   \n",
+       "750000593  750001777         -1         -1          1  1469.3          1   \n",
+       "750001777  750002369  750000000  750000593          2  1050.9          2   \n",
+       "750000002  750004146         -1         -1          1  3551.0          1   \n",
+       "...              ...        ...        ...        ...     ...        ...   \n",
+       "750000587         -1         -1         -1          1  2354.1          1   \n",
+       "750001180         -1         -1         -1          1  1326.7          1   \n",
+       "750001772         -1         -1         -1          1  1000.1          1   \n",
+       "750000588         -1         -1         -1          1  2044.7          1   \n",
+       "750000589         -1         -1         -1          1   868.5          1   \n",
+       "\n",
+       "           DSContArea  strmDrop     Slope  StraightL  USContArea  DOUTEND  \\\n",
+       "LINKNO                                                                      \n",
+       "750000000   9567845.0     42.07  0.010933     3233.7   5254867.5  45853.6   \n",
+       "750000001   8768556.0     34.66  0.015397     1749.2   4320561.0  44802.7   \n",
+       "750000593   8466694.0     11.98  0.008153     1286.2   4319318.0  45853.6   \n",
+       "750001777  19939082.0      0.91  0.000870      871.8  18034788.0  44802.7   \n",
+       "750000002   9120895.0     67.48  0.019002     2593.6   5267176.0  41041.1   \n",
+       "...               ...       ...       ...        ...         ...      ...   \n",
+       "750000587  10233235.0      0.00  0.000000     1721.9   7569312.0      0.0   \n",
+       "750001180   9136435.0      0.00  0.000000     1072.3   4495984.5      0.0   \n",
+       "750001772   4879280.0      0.00  0.000000      738.8   4387448.5      0.0   \n",
+       "750000588   5911555.0      0.76  0.000370     1396.2   4346421.0      0.0   \n",
+       "750000589   5180645.5      0.00  0.000000      775.9   5107666.0      0.0   \n",
+       "\n",
+       "           DOUTSTART  DOUTMID  \\\n",
+       "LINKNO                          \n",
+       "750000000    49701.4  47777.5   \n",
+       "750000001    47054.1  45928.4   \n",
+       "750000593    47322.9  46588.3   \n",
+       "750001777    45853.6  45328.2   \n",
+       "750000002    44591.7  42816.4   \n",
+       "...              ...      ...   \n",
+       "750000587     2354.1   1177.1   \n",
+       "750001180     1326.7    663.4   \n",
+       "750001772     1000.1    500.0   \n",
+       "750000588     2044.7   1022.4   \n",
+       "750000589      868.5    434.3   \n",
+       "\n",
+       "                                                    geometry  \n",
+       "LINKNO                                                        \n",
+       "750000000  LINESTRING (-69.67822 46.41356, -69.67822 46.4...  \n",
+       "750000001  LINESTRING (-69.68589 46.40778, -69.686 46.407...  \n",
+       "750000593  LINESTRING (-69.67822 46.41356, -69.67811 46.4...  \n",
+       "750001777  LINESTRING (-69.68589 46.40778, -69.68589 46.4...  \n",
+       "750000002  LINESTRING (-69.687 46.37911, -69.687 46.379, ...  \n",
+       "...                                                      ...  \n",
+       "750000587  LINESTRING (-81.59922 24.64033, -81.59911 24.6...  \n",
+       "750001180  LINESTRING (-81.63022 24.61767, -81.63011 24.6...  \n",
+       "750001772  LINESTRING (-81.60144 24.58478, -81.60156 24.5...  \n",
+       "750000588  LINESTRING (-81.64478 24.57489, -81.64489 24.5...  \n",
+       "750000589  LINESTRING (-81.68 24.559, -81.68011 24.55911,...  \n",
+       "\n",
+       "[140097 rows x 15 columns]"
+      ]
+     },
+     "execution_count": 132,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "stream_mnsi_gdf.drop(columns=gh.mnsi.MNSI_FIELDS)\n"
    ]
   },
   {
@@ -1926,6 +2638,31 @@
     "# at column locations right after other LINK info\n",
     "for f in (FINISH, DISCOVER, ROOT):\n",
     "    basins_gdf.insert(0, f, None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 133,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "streamnet x\n",
+      "streamreach_basins_mnsi y\n",
+      "streams_no_basin z\n"
+     ]
+    }
+   ],
+   "source": [
+    "gdf_dict = {\n",
+    "        'streamnet': 'x',\n",
+    "        'streamreach_basins_mnsi': 'y',\n",
+    "        'streams_no_basin': 'z',\n",
+    "    }\n",
+    "for dataset, gdf in gdf_dict.items():\n",
+    "    print(dataset, gdf)"
    ]
   },
   {

--- a/src/global_hydrography/__init__.py
+++ b/src/global_hydrography/__init__.py
@@ -6,4 +6,10 @@ Watershed.
 # populate package namespace
 from global_hydrography import (
     io,
+    preprocess,
+    process,
+)
+
+from global_hydrography.delineation import (
+    mnsi,
 )

--- a/src/global_hydrography/delineation/mnsi.py
+++ b/src/global_hydrography/delineation/mnsi.py
@@ -15,6 +15,7 @@ DS_LINK = "DSLINKNO"
 DISCOVER = "DISCOVER_TIME"
 FINISH = "FINISH_TIME"
 ROOT = "ROOT_ID"
+MNSI_FIELDS = [ROOT, FINISH, DISCOVER]
 
 
 def modified_nest_set_index(df: DataFrame) -> DataFrame:

--- a/src/global_hydrography/process.py
+++ b/src/global_hydrography/process.py
@@ -5,6 +5,7 @@ import geopandas as gpd
 import pandas as pd
 
 from global_hydrography.preprocess import TDXPreprocessor
+from global_hydrography.delineation.mnsi import MNSI_FIELDS
 
 
 
@@ -12,7 +13,7 @@ def select_tdx_files(
     directory_path: Path,
     tdxhydroregion: int,
     file_extension: str,
-)-> list[Path]:
+)-> tuple[Path]:
     """Select pairs of TDX 'streamnet' and 'streamreach_basins'
     files for processing together.
 
@@ -27,9 +28,45 @@ def select_tdx_files(
             str(tdxhydroregion) in item.name
         ):
             if 'streamnet' in item.name:
-                streamnet_file = item
+                streamnet_filepath = item
             if 'basins' in item.name:
-                basins_file = item
+                basins_filepath = item
 
-    return (streamnet_file, basins_file)
+    return (streamnet_filepath, basins_filepath)
+
+
+def create_basins_mnsi(
+    basins_gdf: gpd.GeoDataFrame,
+    streams_mnsi_gdf: gpd.GeoDataFrame,
+)-> tuple[gpd.GeoDataFrame]:
+    """Create Basins GeoDataFrame with MNSI fields from streamnet_mnsi_gdf.
+
+    Parameters:
+        basins_gdf: TDX Streamreach Basins dataset, with 'streamID' renamed to 'LINKNO'.
+        streams_mnsi_gdf: TDX Stream Network dataset with MNSI fields added.
+
+    Return: A tuple of GeoDataFrames
+        basins_mnsi_gdf: A copy of the basins_gdf appended with three MNSI fields.
+        streams_no_basin_gdf: A gdf of the streamnet LINKs that have no associated basins.
+    """
+    
+    # Perform a right join, for all rows in streamnet,
+    # potentially creating some rows with no basin geometries
+    basins_mnsi_gdf = pd.merge(
+        basins_gdf, 
+        streams_mnsi_gdf[MNSI_FIELDS], 
+        how='right', 
+        on='LINKNO',
+    )
+    # Save streamnet rows that don't have a basin geometry
+    streams_no_basin_gdf = streams_mnsi_gdf[basins_mnsi_gdf.geometry==None].copy(deep=True)
+
+    # Drop no-geometry rows from basins gdf
+    basins_mnsi_gdf.drop(
+        streams_no_basin_gdf.index.to_list(), 
+        inplace=True,
+    )
+    
+    return (basins_mnsi_gdf, streams_no_basin_gdf)
+
 

--- a/src/global_hydrography/process.py
+++ b/src/global_hydrography/process.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+import re
+import pyogrio
+import geopandas as gpd
+import pandas as pd
+
+from global_hydrography.preprocess import TDXPreprocessor
+
+
+
+def select_tdx_files(
+    directory_path: Path,
+    tdxhydroregion: int,
+    file_extension: str,
+)-> list[Path]:
+    """Select pairs of TDX 'streamnet' and 'streamreach_basins'
+    files for processing together.
+
+    Parameters:
+        directory_path: Local directory path to where files are located.
+        tdxhydroregion: 10-digit region code used to organize TDXHydro files
+            and taken from HydroBASINS Level 2 IDs.
+    """
+    for item in directory_path.iterdir():
+        if (item.is_file() and 
+            item.suffix==file_extension and
+            str(tdxhydroregion) in item.name
+        ):
+            if 'streamnet' in item.name:
+                streamnet_file = item
+            if 'basins' in item.name:
+                basins_file = item
+
+    return (streamnet_file, basins_file)
+


### PR DESCRIPTION
With the `process_tdx_streams_basins()` helper function at the end of `examples/4_ProcessBasinToParquet.ipynb`, we have an efficient processing pipeline to:

Process a pair of TDXHydro streamnet and streamreach_basins files for a given TDX Hydro Region, creating a set of GeoParquet files ready for use by Model My Watershed. This processing:
- Reads the 'TDX_streamnet*.gpkg' file provided by NGA, converts LINKNO fields to globally unique values, calculates and adds three new Modified Nested Set Index (MNSI) fields, drops useless fields, and sets LINKNO as the index.
- Reads the 'TDX_streareach_basins*.gpkg' file provided by NGA, renames 'streamID' to LINKNO, converts LINKNO to globally unique values, and sets LINKNO as the index.
- Moves MNSI fields from streament to basins datasets, saving a dataset of streams that don't have a matching basin geometry.
- Saves three output datasets to GeoParquet files in the output directory.

For TDXHydroRegion = 7020038340 (Eastern USA), it takes 54 seconds on my laptop, taking advantage of the performance optimization described in #1, #3, #4. The `process_tdx_streams_basins()` blends Paul's `create_tdx_mnsi()` and my `process_tdx_basins()` created earlier in example notebooks 3 and 4 with our recent realizations that MNSI fields belong with Basins.

This pipeline does not include the basins aggregation/dissolve/simplify functions that @ptomasula is developing.

Fortunately, I think we can run this pipeline first, followed by @ptomasula's geospatial processing of basin geometries, which reads only 1 of the 3 files produced by this pipeline and does not alter the file it reads. Rather Paul's geospatial processing creates a new set of smaller basin files with new geometries to facilitate geospatial functions in Model My Watershed.

@kieranbartels, I think this is ready for you to implement.